### PR TITLE
Add support for adding components to bone nodes

### DIFF
--- a/io_scene_hubs/components.py
+++ b/io_scene_hubs/components.py
@@ -49,6 +49,8 @@ def is_object_source_component(object_source, component_definition):
 def get_object_source(context, object_source):
     if object_source == "material":
         return context.material
+    elif object_source == "bone":
+        return context.bone or context.edit_bone
     elif object_source == "scene":
         return context.scene
     else:
@@ -258,6 +260,8 @@ def register():
     bpy.types.Object.hubs_component_list = PointerProperty(type=HubsComponentList)
     bpy.types.Scene.hubs_component_list = PointerProperty(type=HubsComponentList)
     bpy.types.Material.hubs_component_list = PointerProperty(type=HubsComponentList)
+    bpy.types.Bone.hubs_component_list = PointerProperty(type=HubsComponentList)
+    bpy.types.EditBone.hubs_component_list = PointerProperty(type=HubsComponentList)
     bpy.types.Scene.HubsComponentsExtensionProperties = PointerProperty(type=HubsComponentsExtensionProperties)
 
 def unregister():
@@ -270,4 +274,6 @@ def unregister():
     del bpy.types.Object.hubs_component_list
     del bpy.types.Scene.hubs_component_list
     del bpy.types.Material.hubs_component_list
+    del bpy.types.Bone.hubs_component_list
+    del bpy.types.EditBone.hubs_component_list
     del bpy.types.Scene.HubsComponentsExtensionProperties

--- a/io_scene_hubs/panels.py
+++ b/io_scene_hubs/panels.py
@@ -41,6 +41,16 @@ class HubsMaterialPanel(Panel):
     def draw(self, context):
         draw_components_list(self, context)
 
+class HubsBonePanel(Panel):
+    bl_label = "Hubs"
+    bl_idname = "BONE_PT_hubs"
+    bl_space_type = 'PROPERTIES'
+    bl_region_type = 'WINDOW'
+    bl_context = "bone"
+
+    def draw(self, context):
+        draw_components_list(self, context)
+
 class HubsGLTFExportPanel(bpy.types.Panel):
 
     bl_space_type = 'FILE_BROWSER'
@@ -210,8 +220,10 @@ def register():
     bpy.utils.register_class(HubsScenePanel)
     bpy.utils.register_class(HubsObjectPanel)
     bpy.utils.register_class(HubsMaterialPanel)
+    bpy.utils.register_class(HubsBonePanel)
 
 def unregister():
     bpy.utils.unregister_class(HubsScenePanel)
     bpy.utils.unregister_class(HubsObjectPanel)
     bpy.utils.unregister_class(HubsMaterialPanel)
+    bpy.utils.unregister_class(HubsBonePanel)

--- a/io_scene_hubs/settings.py
+++ b/io_scene_hubs/settings.py
@@ -50,6 +50,12 @@ def unregister_components():
                 component_class_name = get_component_class_name(component_name)
                 if hasattr(bpy.types.Object, component_class_name):
                     delattr(bpy.types.Object, component_class_name)
+                if hasattr(bpy.types.Material, component_class_name):
+                    delattr(bpy.types.Material, component_class_name)
+                if hasattr(bpy.types.Bone, component_class_name):
+                    delattr(bpy.types.Bone, component_class_name)
+                if hasattr(bpy.types.EditBone, component_class_name):
+                    delattr(bpy.types.EditBone, component_class_name)
 
         if 'registered_hubs_classes' in hubs_context:
             for class_name, registered_class in hubs_context['registered_hubs_classes']:
@@ -87,6 +93,16 @@ def register_components():
         if not 'node' in component_definition or component_definition['node']:
             setattr(
                 bpy.types.Object,
+                get_component_class_name(component_name),
+                PointerProperty(type=component_class)
+            )
+            setattr(
+                bpy.types.Bone,
+                get_component_class_name(component_name),
+                PointerProperty(type=component_class)
+            )
+            setattr(
+                bpy.types.EditBone,
                 get_component_class_name(component_name),
                 PointerProperty(type=component_class)
             )


### PR DESCRIPTION
This adds a "Hubs" section to the "bones" property panel, allowing you to add components to bone nodes. Didn't add a new component schema flag for this, since bones are just "nodes" in the gltf, so any component that can be added to "nodes" should be able to be added to "bones" as well.

![image](https://user-images.githubusercontent.com/130735/79031189-ec955b00-7b51-11ea-9a1f-c8dfbcfc930c.png)

This requires another monkeypatch to add a `gather_joint_hook`, will submit a PR uppstream for this, I don't suspect it should be able to be merged quickly since completely in line with how the rest of the hooks work and has no open questions like the other hook we have monkeypatched.

(sidenote: I doubt we are going to end up needing to add many more of these since there are not that many more core gltf types we will want to add components to, but figuring out where all I had to extend to add components to another Blender type was a bit of a pain, this PR serves as a nice template to look at later, but next time we find ourselves wanting to add one it may be worth DRYing a bit)