### PR TITLE
Rename references of Hubs to Moz Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# Hubs Exporter for Blender
+# GLTF MOZ_Components Exporter for Blender
 
-This addon extends the glTF 2.0 exporter to support the `MOZ_hubs_components` extension allowing you to add behavior to glTF assets for [Mozilla Hubs](https://hubs.mozilla.com).
+This addon extends the glTF 2.0 exporter to support the `MOZ_components` extension allowing you to add behavior to glTF assets.

--- a/io_scene_mozcomponents/__init__.py
+++ b/io_scene_mozcomponents/__init__.py
@@ -7,7 +7,7 @@ from . import panels
 from .gather_properties import gather_properties
 
 bl_info = {
-    "name" : "io_scene_hubs",
+    "name" : "io_scene_mozcomponents",
     "author" : "Robert Long",
     "description" : "",
     "blender" : (2, 82, 0),
@@ -51,7 +51,7 @@ if __name__ == "__main__":
 # called by gltf-blender-io after it has loaded
 def register_panel():
     try:
-        bpy.utils.register_class(panels.HubsGLTFExportPanel)
+        bpy.utils.register_class(panels.MozComponentsGLTFExportPanel)
     except Exception:
         pass
     return unregister_export_panel
@@ -59,7 +59,7 @@ def register_panel():
 def unregister_export_panel():
     # Since panel is registered on demand, it is possible it is not registered
     try:
-        bpy.utils.unregister_class(panels.HubsGLTFExportPanel)
+        bpy.utils.unregister_class(panels.MozComponentsGLTFExportPanel)
     except Exception:
         pass
 
@@ -70,18 +70,18 @@ class glTF2ExportUserExtension:
         # Otherwise, it may fail because the gltf2 may not be loaded yet
         from io_scene_gltf2.io.com.gltf2_io_extensions import Extension
         self.Extension = Extension
-        self.properties = bpy.context.scene.HubsComponentsExtensionProperties
-        self.hubs_settings = bpy.context.scene.hubs_settings
+        self.properties = bpy.context.scene.MozComponentsExtensionProperties
+        self.mozcomponents_settings = bpy.context.scene.mozcomponents_settings
 
     def gather_gltf_hook(self, gltf2_object, export_settings):
         if not self.properties.enabled: return
 
-        hubs_config = self.hubs_settings.hubs_config
-        extension_name = hubs_config["gltfExtensionName"]
+        mozcomponents_config = self.mozcomponents_settings.mozcomponents_config
+        extension_name = mozcomponents_config["gltfExtensionName"]
         gltf2_object.extensions[extension_name] = self.Extension(
             name=extension_name,
             extension={
-                "version": hubs_config["gltfExtensionVersion"]
+                "version": mozcomponents_config["gltfExtensionVersion"]
             },
             required=False
         )
@@ -89,30 +89,30 @@ class glTF2ExportUserExtension:
     def gather_node_hook(self, gltf2_object, blender_object, export_settings):
         if not self.properties.enabled: return
 
-        self.add_hubs_components(gltf2_object, blender_object, export_settings)
+        self.add_mozcomponents_components(gltf2_object, blender_object, export_settings)
 
     def gather_material_hook(self, gltf2_object, blender_object, export_settings):
         if not self.properties.enabled: return
 
-        self.add_hubs_components(gltf2_object, blender_object, export_settings)
+        self.add_mozcomponents_components(gltf2_object, blender_object, export_settings)
 
-    def add_hubs_components(self, gltf2_object, blender_object, export_settings):
-        component_list = blender_object.hubs_component_list
+    def add_mozcomponents_components(self, gltf2_object, blender_object, export_settings):
+        component_list = blender_object.mozcomponents_component_list
 
-        hubs_config = self.hubs_settings.hubs_config
-        registered_hubs_components = self.hubs_settings.registered_hubs_components
+        mozcomponents_config = self.mozcomponents_settings.mozcomponents_config
+        registered_moz_components = self.mozcomponents_settings.registered_moz_components
 
         if component_list.items:
-            extension_name = hubs_config["gltfExtensionName"]
+            extension_name = mozcomponents_config["gltfExtensionName"]
             component_data = {}
 
             for component_item in component_list.items:
                 component_name = component_item.name
-                component_definition = hubs_config['components'][component_name]
-                component_class = registered_hubs_components[component_name]
+                component_definition = mozcomponents_config['components'][component_name]
+                component_class = registered_moz_components[component_name]
                 component_class_name = component_class.__name__
                 component = getattr(blender_object, component_class_name)
-                component_data[component_name] = gather_properties(export_settings, blender_object, component, component_definition, hubs_config)
+                component_data[component_name] = gather_properties(export_settings, blender_object, component, component_definition, mozcomponents_config)
 
             if gltf2_object.extensions is None:
                 gltf2_object.extensions = {}

--- a/io_scene_mozcomponents/default-config.json
+++ b/io_scene_mozcomponents/default-config.json
@@ -1,6 +1,6 @@
 {
   "configVersion": 1,
-  "gltfExtensionName": "MOZ_hubs_components",
+  "gltfExtensionName": "MOZ_components",
   "gltfExtensionVersion": 3,
   "types": {
     "MaterialItem": {

--- a/io_scene_mozcomponents/gather_properties.py
+++ b/io_scene_mozcomponents/gather_properties.py
@@ -5,30 +5,30 @@ import bpy
 from io_scene_gltf2.blender.exp import gltf2_blender_gather_materials
 from io_scene_gltf2.blender.com import gltf2_blender_extras
 
-def gather_properties(export_settings, blender_object, target, type_definition, hubs_config):
+def gather_properties(export_settings, blender_object, target, type_definition, mozcomponents_config):
     value = {}
 
     for property_name, property_definition in type_definition['properties'].items():
-        value[property_name] = gather_property(export_settings, blender_object, target, property_name, property_definition, hubs_config)
+        value[property_name] = gather_property(export_settings, blender_object, target, property_name, property_definition, mozcomponents_config)
 
     return value
 
-def gather_property(export_settings, blender_object, target, property_name, property_definition, hubs_config):
+def gather_property(export_settings, blender_object, target, property_name, property_definition, mozcomponents_config):
     property_type = property_definition['type']
 
     if property_type == 'material':
-        return gather_material_property(export_settings, blender_object, target, property_name, property_definition, hubs_config)
+        return gather_material_property(export_settings, blender_object, target, property_name, property_definition, mozcomponents_config)
     elif property_type == 'collections':
-        return gather_collections_property(export_settings, blender_object, target, property_name, property_definition, hubs_config)
+        return gather_collections_property(export_settings, blender_object, target, property_name, property_definition, mozcomponents_config)
     elif property_type == 'array':
-        return gather_array_property(export_settings, blender_object, target, property_name, property_definition, hubs_config)
+        return gather_array_property(export_settings, blender_object, target, property_name, property_definition, mozcomponents_config)
     else:
         return gltf2_blender_extras.__to_json_compatible(getattr(target, property_name))
 
-def gather_array_property(export_settings, blender_object, target, property_name, property_definition, hubs_config):
+def gather_array_property(export_settings, blender_object, target, property_name, property_definition, mozcomponents_config):
     array_type = property_definition['arrayType']
     print(array_type)
-    type_definition = hubs_config['types'][array_type]
+    type_definition = mozcomponents_config['types'][array_type]
     is_value_type = len(type_definition['properties']) == 1 and 'value' in type_definition['properties']
     value = []
 
@@ -36,14 +36,14 @@ def gather_array_property(export_settings, blender_object, target, property_name
 
     for item in arr:
         if is_value_type:
-            item_value = gather_property(export_settings, blender_object, item, "value", type_definition['properties']['value'], hubs_config)
+            item_value = gather_property(export_settings, blender_object, item, "value", type_definition['properties']['value'], mozcomponents_config)
         else:
-            item_value = gather_properties(export_settings, blender_object, item, type_definition, hubs_config)
+            item_value = gather_properties(export_settings, blender_object, item, type_definition, mozcomponents_config)
         value.append(item_value)
     
     return value
 
-def gather_material_property(export_settings, blender_object, target, property_name, property_definition, hubs_config):
+def gather_material_property(export_settings, blender_object, target, property_name, property_definition, mozcomponents_config):
     blender_material = getattr(target, property_name)
 
     if blender_material:
@@ -54,7 +54,7 @@ def gather_material_property(export_settings, blender_object, target, property_n
     else:
         return None
 
-def gather_collections_property(export_settings, blender_object, target, property_name, property_definition, hubs_config):
+def gather_collections_property(export_settings, blender_object, target, property_name, property_definition, mozcomponents_config):
     filtered_collection_names = []
 
     collection_prefix_regex = None

--- a/io_scene_mozcomponents/panels.py
+++ b/io_scene_mozcomponents/panels.py
@@ -4,9 +4,9 @@ from bpy.types import Panel
 from bpy.props import StringProperty
 from . import components
 
-class HubsScenePanel(Panel):
-    bl_label = 'Hubs'
-    bl_idname = "SCENE_PT_hubs"
+class MozComponentsScenePanel(Panel):
+    bl_label = 'Moz Components'
+    bl_idname = "SCENE_PT_mozcomponents"
     bl_space_type = 'PROPERTIES'
     bl_region_type = 'WINDOW'
     bl_context = 'scene'
@@ -15,15 +15,15 @@ class HubsScenePanel(Panel):
         layout = self.layout
 
         row = layout.row()
-        row.prop(context.scene.hubs_settings,
+        row.prop(context.scene.mozcomponents_settings,
                  "config_path", text="Config File")
-        row.operator("wm.reload_hubs_config", text="", icon="FILE_REFRESH")
+        row.operator("wm.reload_mozcomponents_config", text="", icon="FILE_REFRESH")
 
         draw_components_list(self, context)
 
-class HubsObjectPanel(Panel):
-    bl_label = "Hubs"
-    bl_idname = "OBJECT_PT_hubs"
+class MozComponentsObjectPanel(Panel):
+    bl_label = "Moz Components"
+    bl_idname = "OBJECT_PT_mozcomponents"
     bl_space_type = 'PROPERTIES'
     bl_region_type = 'WINDOW'
     bl_context = "object"
@@ -31,9 +31,9 @@ class HubsObjectPanel(Panel):
     def draw(self, context):
         draw_components_list(self, context)
 
-class HubsMaterialPanel(Panel):
-    bl_label = 'Hubs'
-    bl_idname = "MATERIAL_PT_hubs"
+class MozComponentsMaterialPanel(Panel):
+    bl_label = 'Moz Components'
+    bl_idname = "MATERIAL_PT_mozcomponents"
     bl_space_type = 'PROPERTIES'
     bl_region_type = 'WINDOW'
     bl_context = 'material'
@@ -41,11 +41,11 @@ class HubsMaterialPanel(Panel):
     def draw(self, context):
         draw_components_list(self, context)
 
-class HubsGLTFExportPanel(bpy.types.Panel):
+class MozComponentsGLTFExportPanel(bpy.types.Panel):
 
     bl_space_type = 'FILE_BROWSER'
     bl_region_type = 'TOOL_PROPS'
-    bl_label = "Hubs Components"
+    bl_label = "MOZ Components"
     bl_parent_id = "GLTF_PT_export_user_extensions"
     bl_options = {'DEFAULT_CLOSED'}
 
@@ -56,7 +56,7 @@ class HubsGLTFExportPanel(bpy.types.Panel):
         return operator.bl_idname == "EXPORT_SCENE_OT_gltf"
 
     def draw_header(self, context):
-        props = bpy.context.scene.HubsComponentsExtensionProperties
+        props = bpy.context.scene.MozComponentsExtensionProperties
         self.layout.prop(props, 'enabled', text="")
 
     def draw(self, context):
@@ -64,7 +64,7 @@ class HubsGLTFExportPanel(bpy.types.Panel):
         layout.use_property_split = True
         layout.use_property_decorate = False  # No animation.
 
-        props = bpy.context.scene.HubsComponentsExtensionProperties
+        props = bpy.context.scene.MozComponentsExtensionProperties
         layout.active = props.enabled
 
         box = layout.box()
@@ -81,30 +81,30 @@ def draw_components_list(panel, context):
         layout.label(text="No object selected")
         return
 
-    hubs_settings = context.scene.hubs_settings
+    mozcomponents_settings = context.scene.mozcomponents_settings
 
-    if hubs_settings.hubs_config is None:
-        layout.label(text="No hubs config loaded")
+    if mozcomponents_settings.mozcomponents_config is None:
+        layout.label(text="No mozcomponents config loaded")
         return
 
-    for component_item in obj.hubs_component_list.items:
+    for component_item in obj.mozcomponents_component_list.items:
         row = layout.row()
         draw_component(panel, context, obj, row, component_item)
 
     layout.separator()
 
     add_component_operator = layout.operator(
-        "wm.add_hubs_component",
+        "wm.add_mozcomponents_component",
         text="Add Component"
     )
     add_component_operator.object_source = panel.bl_context
 
 def draw_component(panel, context, obj, row, component_item):
-    hubs_settings = context.scene.hubs_settings
+    mozcomponents_settings = context.scene.mozcomponents_settings
 
     component_name = component_item.name
-    component_definition = hubs_settings.hubs_config['components'][component_name]
-    component_class = hubs_settings.registered_hubs_components[component_name]
+    component_definition = mozcomponents_settings.mozcomponents_config['components'][component_name]
+    component_class = mozcomponents_settings.registered_moz_components[component_name]
     component_class_name = component_class.__name__
     component = getattr(obj, component_class_name)
 
@@ -113,13 +113,13 @@ def draw_component(panel, context, obj, row, component_item):
     top_row.label(text=component_name)
 
     copy_component_operator = top_row.operator(
-        "wm.copy_hubs_component",
+        "wm.copy_mozcomponents_component",
         text="Copy"
     )
     copy_component_operator.component_name = component_name
 
     remove_component_operator = top_row.operator(
-        "wm.remove_hubs_component",
+        "wm.remove_mozcomponents_component",
         text="",
         icon="X"
     )
@@ -138,8 +138,8 @@ def draw_type(context, col, obj, target, path, type_definition):
 
 def draw_property(context, col, obj, target, path, property_name, property_definition):
     property_type = property_definition['type']
-    hubs_settings = context.scene.hubs_settings
-    registered_types = hubs_settings.hubs_config['types']
+    mozcomponents_settings = context.scene.mozcomponents_settings
+    registered_types = mozcomponents_settings.mozcomponents_config['types']
     is_custom_type = property_type in registered_types
 
     if property_type == 'collections':
@@ -174,8 +174,8 @@ def draw_collections_property(_context, col, obj, _target, _path, property_name,
     collections_row.box().label(text=", ".join(filtered_collection_names))
 
 def draw_array_property(context, col, obj, target, path, property_name, property_definition):
-    hubs_settings = context.scene.hubs_settings
-    registered_types = hubs_settings.hubs_config['types']
+    mozcomponents_settings = context.scene.mozcomponents_settings
+    registered_types = mozcomponents_settings.mozcomponents_config['types']
     array_type = property_definition['arrayType']
     item_definition = registered_types[array_type]
 
@@ -194,24 +194,24 @@ def draw_array_property(context, col, obj, target, path, property_name, property
         draw_type(context, box_col, obj, item, item_path, item_definition)
 
         remove_operator = box_row.column().operator(
-            "wm.remove_hubs_component_item",
+            "wm.remove_mozcomponents_component_item",
             text="",
             icon="X"
         )
         remove_operator.path = item_path
 
     add_operator = col.operator(
-        "wm.add_hubs_component_item",
+        "wm.add_mozcomponents_component_item",
         text="Add Item"
     )
     add_operator.path = property_path
 
 def register():
-    bpy.utils.register_class(HubsScenePanel)
-    bpy.utils.register_class(HubsObjectPanel)
-    bpy.utils.register_class(HubsMaterialPanel)
+    bpy.utils.register_class(MozComponentsScenePanel)
+    bpy.utils.register_class(MozComponentsObjectPanel)
+    bpy.utils.register_class(MozComponentsMaterialPanel)
 
 def unregister():
-    bpy.utils.unregister_class(HubsScenePanel)
-    bpy.utils.unregister_class(HubsObjectPanel)
-    bpy.utils.unregister_class(HubsMaterialPanel)
+    bpy.utils.unregister_class(MozComponentsScenePanel)
+    bpy.utils.unregister_class(MozComponentsObjectPanel)
+    bpy.utils.unregister_class(MozComponentsMaterialPanel)

--- a/io_scene_mozcomponents/settings.py
+++ b/io_scene_mozcomponents/settings.py
@@ -13,68 +13,68 @@ default_config_filename = 'default-config.json'
 default_config_path = default_config_filename
 
 for path in paths:
-    default_config_path = os.path.join(path, "io_scene_hubs", default_config_filename)
+    default_config_path = os.path.join(path, "io_scene_mozcomponents", default_config_filename)
     if os.path.exists(default_config_path):
         break
 
 def get_component_class_name(component_name):
-    return "hubs_component_%s" % component_name.replace('-', '_')
+    return "moz_component_%s" % component_name.replace('-', '_')
 
 def reload_context(config_path):
-    global hubs_context
+    global mozcomponents_context
 
     if os.path.splitext(config_path)[1] == '.json':
         with open(bpy.path.abspath(config_path)) as config_file:
-            hubs_config = json.load(config_file)
+            mozcomponents_config = json.load(config_file)
     else:
-        hubs_config = None
+        mozcomponents_config = None
         print('Config must be a .json file!')
 
-    if 'hubs_context' in globals():
+    if 'mozcomponents_context' in globals():
         unregister_components()
 
-    hubs_context = {
-        'registered_hubs_components': {},
+    mozcomponents_context = {
+        'registered_moz_components': {},
         'registered_classes': {},
-        'hubs_config': hubs_config
+        'mozcomponents_config': mozcomponents_config
     }
 
     register_components()
 
 def unregister_components():
-    global hubs_context
+    global mozcomponents_context
 
     try:
-        if 'registered_hubs_components' in hubs_context:
-            for component_name, component_class in hubs_context['registered_hubs_components'].items():
+        if 'registered_moz_components' in mozcomponents_context:
+            for component_name, component_class in mozcomponents_context['registered_moz_components'].items():
                 component_class_name = get_component_class_name(component_name)
                 if hasattr(bpy.types.Object, component_class_name):
                     delattr(bpy.types.Object, component_class_name)
 
-        if 'registered_hubs_classes' in hubs_context:
-            for class_name, registered_class in hubs_context['registered_hubs_classes']:
+        if 'registered_moz_classes' in mozcomponents_context:
+            for class_name, registered_class in mozcomponents_context['registered_moz_classes']:
                 bpy.utils.unregister_class(registered_class)
 
 
     except UnboundLocalError:
         pass
 
-    if 'registered_hubs_components' in hubs_context:
-        hubs_context['registered_hubs_components'] = {}
+    if 'registered_moz_components' in mozcomponents_context:
+        mozcomponents_context['registered_moz_components'] = {}
 
-    if 'registered_hubs_classes' in hubs_context:
-        hubs_context['registered_hubs_classes'] = {}
+    if 'registered_moz_classes' in mozcomponents_context:
+        mozcomponents_context['registered_moz_classes'] = {}
 
 def register_components():
-    global hubs_context
+    global mozcomponents_context
 
-    for component_name, component_definition in hubs_context['hubs_config']['components'].items():
-        class_name = "hubs_component_%s" % component_name.replace('-', '_')
+    for component_name, component_definition in mozcomponents_context['mozcomponents_config']['components'].items():
+        class_name = "moz_component_%s" % component_name.replace('-', '_')
 
         component_class = components.define_class(
             class_name,
             component_definition,
-            hubs_context
+            mozcomponents_context
         )
 
         if 'scene' in component_definition and component_definition['scene']:
@@ -98,16 +98,16 @@ def register_components():
                 PointerProperty(type=component_class)
             )
 
-        hubs_context['registered_hubs_components'][component_name] = component_class
+        mozcomponents_context['registered_moz_components'][component_name] = component_class
 
 @persistent
 def load_handler(_dummy):
-    reload_context(bpy.context.scene.hubs_settings.config_path)
+    reload_context(bpy.context.scene.mozcomponents_settings.config_path)
 
 def config_updated(self, _context):
     load_handler(self)
 
-class HubsSettings(PropertyGroup):
+class MozComponentsSettings(PropertyGroup):
     config_path: StringProperty(
         name="config_path",
         description="Path to the config file",
@@ -119,30 +119,30 @@ class HubsSettings(PropertyGroup):
     )
 
     @property
-    def hubs_config(self):
-        global hubs_context
-        return hubs_context['hubs_config']
+    def mozcomponents_config(self):
+        global mozcomponents_context
+        return mozcomponents_context['mozcomponents_config']
 
     @property
-    def registered_hubs_components(self):
-        return hubs_context['registered_hubs_components']
+    def registered_moz_components(self):
+        return mozcomponents_context['registered_moz_components']
 
     @property
-    def registered_hubs_classes(self):
-        return hubs_context['registered_hubs_classes']
+    def registered_moz_classes(self):
+        return mozcomponents_context['registered_moz_classes']
 
     def reload_config(self):
         reload_context(self.config_path)
 
 def register():
-    bpy.utils.register_class(HubsSettings)
-    bpy.types.Scene.hubs_settings = PointerProperty(type=HubsSettings)
+    bpy.utils.register_class(MozComponentsSettings)
+    bpy.types.Scene.mozcomponents_settings = PointerProperty(type=MozComponentsSettings)
     bpy.app.handlers.load_post.append(load_handler)
     reload_context(default_config_path)
 
 def unregister():
-    global hubs_context
-    del hubs_context
-    bpy.utils.unregister_class(HubsSettings)
-    del bpy.types.Scene.hubs_settings
+    global mozcomponents_context
+    del mozcomponents_context
+    bpy.utils.unregister_class(MozComponentsSettings)
+    del bpy.types.Scene.mozcomponents_settings
     bpy.app.handlers.load_post.remove(load_handler)


### PR DESCRIPTION
I was giving a try to rename the `Hubs` references with a more generic Moz Components as we discussed.
I used the reference branch from @netpro2k #1 
Do you have any strong preference if, when using variables like `hubs_settings` replace them to `mozcomponents_settings` or just `moz_settings` ?
I tested it already in blender and it works as expected.