### PR TITLE
Add lightmap support and upgrade to Blender 2.83

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -4,7 +4,7 @@ from . import settings
 from . import components
 from . import operators
 from . import panels
-from .gather_properties import gather_properties
+from .gather_properties import gather_properties, gather_lightmap_texture_info
 
 bl_info = {
     "name" : "Hubs Blender Exporter",
@@ -84,11 +84,9 @@ class glTF2ExportUserExtension:
         # Otherwise, it may fail because the gltf2 may not be loaded yet
         from io_scene_gltf2.io.com.gltf2_io_extensions import Extension
         from io_scene_gltf2.blender.exp import gltf2_blender_get
-        from io_scene_gltf2.blender.exp import gltf2_blender_gather_texture_info
 
         self.Extension = Extension
         self.gltf2_blender_get = gltf2_blender_get
-        self.gltf2_blender_gather_texture_info = gltf2_blender_gather_texture_info
         self.properties = bpy.context.scene.HubsComponentsExtensionProperties
         self.hubs_settings = bpy.context.scene.hubs_settings
         self.was_used = False
@@ -121,20 +119,11 @@ class glTF2ExportUserExtension:
 
         self.add_hubs_components(gltf2_object, blender_material, export_settings)
 
-        if (
-            blender_material.node_tree
-            and blender_material.use_nodes
-            and blender_material.node_tree.nodes.get("MOZ_lightmap") is not None
-        ):
-            lightmap_texutre = blender_material.node_tree.nodes["MOZ_lightmap"].inputs[
-                "Lightmap"
-            ]
-
+        lightmap_node = blender_material.node_tree and blender_material.use_nodes and blender_material.node_tree.nodes.get("MOZ_lightmap")
+        if (lightmap_node):
             gltf2_object.extensions["MOZ_lightmap"] = self.Extension(
                 name="MOZ_lightmap",
-                extension=self.gltf2_blender_gather_texture_info.gather_texture_info(
-                    (lightmap_texutre,), export_settings
-                ),
+                extension= gather_lightmap_texture_info(lightmap_node, export_settings),
                 required=False,
             )
 

--- a/gather_properties.py
+++ b/gather_properties.py
@@ -4,6 +4,12 @@ import re
 import bpy
 from io_scene_gltf2.blender.exp import gltf2_blender_gather_materials
 from io_scene_gltf2.blender.com import gltf2_blender_extras
+from io_scene_gltf2.blender.exp.gltf2_blender_gather_cache import cached
+from io_scene_gltf2.blender.exp.gltf2_blender_gather_texture_info import (
+    __filter_texture_info,
+    __gather_index,
+    __gather_tex_coord,
+)
 
 def gather_properties(export_settings, blender_object, target, type_definition, hubs_config):
     value = {}
@@ -70,3 +76,22 @@ def gather_collections_property(export_settings, blender_object, target, propert
             filtered_collection_names.append(collection.name)
 
     return filtered_collection_names
+
+@cached
+def gather_lightmap_texture_info(lightmap_node , export_settings):
+    texture = lightmap_node.inputs.get("Lightmap")
+    intensity = lightmap_node.inputs.get("Intensity")
+
+    if not __filter_texture_info((texture,), export_settings):
+        return None
+
+    texture_info = {
+        "intensity": (intensity and intensity.default_value) or 1,
+        "index": __gather_index((texture,), export_settings),
+        "tex_coord": __gather_tex_coord((texture,), export_settings)
+    }
+
+    if texture_info["index"] is None:
+        return None
+
+    return texture_info


### PR DESCRIPTION
This adds support for `MOZ_lightmap` exporting and upgrades to be compatible with Blender 2.83 (it is **NOT** backwards compatible with 2.82, or more specifically the GLTF addon that ships with 2.82)

To export a lightmap, create a "Group" node named `MOZ_lightmap` with a color input property named `Lightmap` and a float input property named `Intensity`. Use a `UV Map` node to control what UV set should be used for the lightmap, as you would any other texture in Blender. 

![image](https://user-images.githubusercontent.com/130735/83697736-a5a56e00-a5b4-11ea-8c7f-e07a19f188a5.png)

Note that fore use in Hubs, you currently MUST use the SECOND UV set, as ThreeJS is currently hardcoded to use that for lightmaps. This will likely be fixed in the future so the exporter does not enforce this.

![image](https://user-images.githubusercontent.com/130735/83697782-b9e96b00-a5b4-11ea-986b-6690c69d8a3f.png)