### PR TITLE
Fix regressions in 2.83 release

### DIFF
--- a/gather_properties.py
+++ b/gather_properties.py
@@ -83,6 +83,8 @@ def gather_lightmap_texture_info(blender_material, export_settings):
     nodes = blender_material.node_tree.nodes
     lightmap_node = next((n for n in nodes if isinstance(n, MozLightmapNode)), None)
 
+    if not lightmap_node: return
+
     texture = lightmap_node.inputs.get("Lightmap")
     intensity = lightmap_node.intensity
 


### PR DESCRIPTION
Bone components and materials without lightmaps regressed in the last release. This fixes them.

Turns out `gather_joint_hook` landed upstream but in the 2.9 release not the 2.83 release, so we sxtill need the monkeypatch. Also we didnt test on materials without lightmaps, so they were throwing errors (though this would only be an issue for components on materials).