### PR TITLE
Media components

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,5 @@
 import bpy
+import uuid
 
 from . import settings
 from . import components
@@ -148,6 +149,7 @@ class glTF2ExportUserExtension:
 
         if component_list.items:
             extension_name = hubs_config["gltfExtensionName"]
+            is_networked = False
             component_data = {}
 
             for component_item in component_list.items:
@@ -157,6 +159,13 @@ class glTF2ExportUserExtension:
                 component_class_name = component_class.__name__
                 component = getattr(blender_object, component_class_name)
                 component_data[component_name] = gather_properties(export_settings, blender_object, component, component_definition, hubs_config)
+                is_networked |= component_name in ("link", "image", "audio", "video")
+
+            # NAF-supported media require a network ID
+            if is_networked:
+                component_data["networked"] = {
+                    "id" : str(uuid.uuid4()).upper()
+                }
 
             if gltf2_object.extensions is None:
                 gltf2_object.extensions = {}

--- a/default-config.json
+++ b/default-config.json
@@ -74,6 +74,214 @@
       "invadingOpacity": { "type": "float", "default": 0.3 }
       }
     },
+    "link": {
+      "category": "Scene",
+      "node": true,
+      "properties": {
+        "href": {
+          "type": "string",
+          "description": "URL"
+        }
+      }
+    },
+    "image": {
+      "category": "Scene",
+      "node": true,
+      "properties": {
+        "src": {
+          "type": "string",
+          "description": "Image URL"
+        },
+        "controls": {
+          "type": "bool", 
+          "description": "Controls",
+          "default": true
+        },
+        "alphaMode": {
+          "type": "enum",
+          "description": "Transparency Mode",
+          "items": [ 
+            [ "opaque", "No transparency (opaque)", "Alpha channel will be ignored" ],
+            [ "blend", "Gradual transparency (blend)", "Alpha channel will be applied" ],
+            [ "mask", "Binary transparency (mask)", "Alpha channel will be used as a threshold between opaque and transparent pixels" ]
+          ]
+        },
+        "projection": {
+          "type": "enum",
+          "description": "Projection",
+          "items": [ 
+            [ "flat", "2D image (flat)", "Image will be shown on a 2D surface" ],
+            [ "360-equirectangular", "Spherical (360-equirectangular)", "Image will be shown on a sphere" ]
+          ]
+        }
+      }
+    },
+    "audio": {
+      "category": "Scene",
+      "node": true,
+      "properties": {
+        "src": {
+          "type": "string",
+          "description": "Audio URL"
+        },
+        "autoPlay": {
+          "type": "bool", 
+          "description": "Auto Play",
+          "default": true
+        },
+        "controls": {
+          "type": "bool", 
+          "description": "Controls",
+          "default": true
+        },
+        "loop": {
+          "type": "bool", 
+          "description": "Loop",
+          "default": true
+        },
+        "audioType": {
+          "type": "enum",
+          "description": "Audio Type",
+          "items": [ 
+            [ "pannernode", "Positional audio (pannernode)", "Volume will change depending on the listener's position relative to the source" ],
+            [ "stereo", "Background audio (stereo)", "Volume will be independent of the listener's position" ]
+          ]
+        },
+        "volume": {
+          "type": "float", 
+          "description": "Volume",
+          "default": 0.5
+        },
+        "distanceModel": {
+          "type": "enum",
+          "description": "Distance Model",
+          "items": [ 
+            [ "inverse", "Inverse drop off (inverse)", "Volume will decrease inversely with distance" ],
+            [ "linear", "Linear drop off (linear)", "Volume will decrease linearly with distance" ],
+            [ "exponential", "Exponential drop off (exponential)", "Volume will decrease expoentially with distance" ]
+          ]
+        },
+        "rolloffFactor": {
+          "type": "float", 
+          "description": "Rolloff Factor",
+          "default": 1.0
+        },
+        "refDistance": {
+          "type": "float", 
+          "description": "Ref Distance",
+          "unit": "LENGTH",
+          "default": 1.0
+        },
+        "maxDistance": {
+          "type": "float", 
+          "description": "Max Distance",
+          "unit": "LENGTH",
+          "default": 10000.0
+        },
+        "coneInnerAngle": {
+          "type": "float", 
+          "description": "Cone Inner Angle",
+          "default": 360.0
+        },
+        "coneOuterAngle": {
+          "type": "float", 
+          "description": "Cone Outer Angle",
+          "default": 360.0
+        },
+        "coneOuterGain": {
+          "type": "float", 
+          "description": "Cone Outer Gain",
+          "default": 0.0
+        }
+      }
+    },
+    "video": {
+      "category": "Scene",
+      "node": true,
+      "properties": {
+        "src": {
+          "type": "string",
+          "description": "Video URL"
+        },
+        "projection": {
+          "type": "enum",
+          "description": "Projection",
+          "items": [ 
+            [ "flat", "2D image (flat)", "Image will be shown on a 2D surface" ],
+            [ "360-equirectangular", "Spherical (360-equirectangular)", "Image will be shown on a sphere" ]
+          ]
+        },
+        "autoPlay": {
+          "type": "bool", 
+          "description": "Auto Play",
+          "default": true
+        },
+        "controls": {
+          "type": "bool", 
+          "description": "Controls",
+          "default": true
+        },
+        "loop": {
+          "type": "bool", 
+          "description": "Loop",
+          "default": true
+        },
+        "audioType": {
+          "type": "enum",
+          "description": "Audio Type",
+          "items": [ 
+            [ "pannernode", "Positional audio (pannernode)", "Volume will change depending on the listener's position relative to the source" ],
+            [ "stereo", "Background audio (stereo)", "Volume will be independent of the listener's position" ]
+          ]
+        },
+        "volume": {
+          "type": "float", 
+          "description": "Volume",
+          "default": 0.5
+        },
+        "distanceModel": {
+          "type": "enum",
+          "description": "Distance Model",
+          "items": [ 
+            [ "inverse", "Inverse drop off (inverse)", "Volume will decrease inversely with distance" ],
+            [ "linear", "Linear drop off (linear)", "Volume will decrease linearly with distance" ],
+            [ "exponential", "Exponential drop off (exponential)", "Volume will decrease expoentially with distance" ]
+          ]
+        },
+        "rolloffFactor": {
+          "type": "float", 
+          "description": "Rolloff Factor",
+          "default": 1.0
+        },
+        "refDistance": {
+          "type": "float", 
+          "description": "Ref Distance",
+          "unit": "LENGTH",
+          "default": 1.0
+        },
+        "maxDistance": {
+          "type": "float", 
+          "description": "Max Distance",
+          "unit": "LENGTH",
+          "default": 10000.0
+        },
+        "coneInnerAngle": {
+          "type": "float", 
+          "description": "Cone Inner Angle",
+          "default": 360.0
+        },
+        "coneOuterAngle": {
+          "type": "float", 
+          "description": "Cone Outer Angle",
+          "default": 360.0
+        },
+        "coneOuterGain": {
+          "type": "float", 
+          "description": "Cone Outer Gain",
+          "default": 0.0
+        }
+      }
+    },
     "nav-mesh": {
       "category": "Scene",
       "node": true,

--- a/default-config.json
+++ b/default-config.json
@@ -35,6 +35,13 @@
     }
   },
   "components": {
+    "visible": {
+      "category": "Scene",
+      "node": true,
+      "properties": {
+      "visible": { "type": "bool", "default": true }
+      }
+    },
     "waypoint": {
       "category": "Scene",
       "node": true,


### PR DESCRIPTION
I've added some of the common component types for export: visible, link, image, audio, and video. The media components all require a *networked* component with a UUID, which allows NAF to track changes. This is added dynamically during export with a new UUID each time as there's no reason that I could think of for this to be persistent.

This pull request includes the previous *visibility* component change that is essential for tidy *nav-mesh* export and desirable for some uses of the *audio* component.

The driver for this is the desire to allow designers to export scenes directly from Blender without needing to go via Spoke. Scene files can be uploaded directly to a Hubs room with the "Custom Scene" option. This greatly simplifies our workflow when dealing with large numbers of scenes and speeds up iteration time.

Feel free to step all over the implementation. I'm an enthusiastic amateur on Blender and an unenthusiastic amateur on Python so it may not be very idiomatic.