### PR TITLE
Root scene components: background, fog, and audio-settings

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,5 @@
 import bpy
+import uuid
 
 from . import settings
 from . import components
@@ -148,6 +149,7 @@ class glTF2ExportUserExtension:
 
         if component_list.items:
             extension_name = hubs_config["gltfExtensionName"]
+            is_networked = False
             component_data = {}
 
             for component_item in component_list.items:
@@ -157,6 +159,13 @@ class glTF2ExportUserExtension:
                 component_class_name = component_class.__name__
                 component = getattr(blender_object, component_class_name)
                 component_data[component_name] = gather_properties(export_settings, blender_object, component, component_definition, hubs_config)
+                is_networked |= component_name in ("link", "image", "audio", "video")
+
+            # NAF-supported media require a network ID
+            if is_networked:
+                component_data["networked"] = {
+                    "id" : str(uuid.uuid4()).upper()
+                }
 
             if gltf2_object.extensions is None:
                 gltf2_object.extensions = {}

--- a/default-config.json
+++ b/default-config.json
@@ -74,6 +74,214 @@
       "invadingOpacity": { "type": "float", "default": 0.3 }
       }
     },
+    "link": {
+      "category": "Scene",
+      "node": true,
+      "properties": {
+        "href": {
+          "type": "string",
+          "description": "URL"
+        }
+      }
+    },
+    "image": {
+      "category": "Scene",
+      "node": true,
+      "properties": {
+        "src": {
+          "type": "string",
+          "description": "Image URL"
+        },
+        "controls": {
+          "type": "bool", 
+          "description": "Controls",
+          "default": true
+        },
+        "alphaMode": {
+          "type": "enum",
+          "description": "Transparency Mode",
+          "items": [ 
+            [ "opaque", "No transparency (opaque)", "Alpha channel will be ignored" ],
+            [ "blend", "Gradual transparency (blend)", "Alpha channel will be applied" ],
+            [ "mask", "Binary transparency (mask)", "Alpha channel will be used as a threshold between opaque and transparent pixels" ]
+          ]
+        },
+        "projection": {
+          "type": "enum",
+          "description": "Projection",
+          "items": [ 
+            [ "flat", "2D image (flat)", "Image will be shown on a 2D surface" ],
+            [ "360-equirectangular", "Spherical (360-equirectangular)", "Image will be shown on a sphere" ]
+          ]
+        }
+      }
+    },
+    "audio": {
+      "category": "Scene",
+      "node": true,
+      "properties": {
+        "src": {
+          "type": "string",
+          "description": "Audio URL"
+        },
+        "autoPlay": {
+          "type": "bool", 
+          "description": "Auto Play",
+          "default": true
+        },
+        "controls": {
+          "type": "bool", 
+          "description": "Controls",
+          "default": true
+        },
+        "loop": {
+          "type": "bool", 
+          "description": "Loop",
+          "default": true
+        },
+        "audioType": {
+          "type": "enum",
+          "description": "Audio Type",
+          "items": [ 
+            [ "pannernode", "Positional audio (pannernode)", "Volume will change depending on the listener's position relative to the source" ],
+            [ "stereo", "Background audio (stereo)", "Volume will be independent of the listener's position" ]
+          ]
+        },
+        "volume": {
+          "type": "float", 
+          "description": "Volume",
+          "default": 0.5
+        },
+        "distanceModel": {
+          "type": "enum",
+          "description": "Distance Model",
+          "items": [ 
+            [ "inverse", "Inverse drop off (inverse)", "Volume will decrease inversely with distance" ],
+            [ "linear", "Linear drop off (linear)", "Volume will decrease linearly with distance" ],
+            [ "exponential", "Exponential drop off (exponential)", "Volume will decrease expoentially with distance" ]
+          ]
+        },
+        "rolloffFactor": {
+          "type": "float", 
+          "description": "Rolloff Factor",
+          "default": 1.0
+        },
+        "refDistance": {
+          "type": "float", 
+          "description": "Ref Distance",
+          "unit": "LENGTH",
+          "default": 1.0
+        },
+        "maxDistance": {
+          "type": "float", 
+          "description": "Max Distance",
+          "unit": "LENGTH",
+          "default": 10000.0
+        },
+        "coneInnerAngle": {
+          "type": "float", 
+          "description": "Cone Inner Angle",
+          "default": 360.0
+        },
+        "coneOuterAngle": {
+          "type": "float", 
+          "description": "Cone Outer Angle",
+          "default": 360.0
+        },
+        "coneOuterGain": {
+          "type": "float", 
+          "description": "Cone Outer Gain",
+          "default": 0.0
+        }
+      }
+    },
+    "video": {
+      "category": "Scene",
+      "node": true,
+      "properties": {
+        "src": {
+          "type": "string",
+          "description": "Video URL"
+        },
+        "projection": {
+          "type": "enum",
+          "description": "Projection",
+          "items": [ 
+            [ "flat", "2D image (flat)", "Image will be shown on a 2D surface" ],
+            [ "360-equirectangular", "Spherical (360-equirectangular)", "Image will be shown on a sphere" ]
+          ]
+        },
+        "autoPlay": {
+          "type": "bool", 
+          "description": "Auto Play",
+          "default": true
+        },
+        "controls": {
+          "type": "bool", 
+          "description": "Controls",
+          "default": true
+        },
+        "loop": {
+          "type": "bool", 
+          "description": "Loop",
+          "default": true
+        },
+        "audioType": {
+          "type": "enum",
+          "description": "Audio Type",
+          "items": [ 
+            [ "pannernode", "Positional audio (pannernode)", "Volume will change depending on the listener's position relative to the source" ],
+            [ "stereo", "Background audio (stereo)", "Volume will be independent of the listener's position" ]
+          ]
+        },
+        "volume": {
+          "type": "float", 
+          "description": "Volume",
+          "default": 0.5
+        },
+        "distanceModel": {
+          "type": "enum",
+          "description": "Distance Model",
+          "items": [ 
+            [ "inverse", "Inverse drop off (inverse)", "Volume will decrease inversely with distance" ],
+            [ "linear", "Linear drop off (linear)", "Volume will decrease linearly with distance" ],
+            [ "exponential", "Exponential drop off (exponential)", "Volume will decrease expoentially with distance" ]
+          ]
+        },
+        "rolloffFactor": {
+          "type": "float", 
+          "description": "Rolloff Factor",
+          "default": 1.0
+        },
+        "refDistance": {
+          "type": "float", 
+          "description": "Ref Distance",
+          "unit": "LENGTH",
+          "default": 1.0
+        },
+        "maxDistance": {
+          "type": "float", 
+          "description": "Max Distance",
+          "unit": "LENGTH",
+          "default": 10000.0
+        },
+        "coneInnerAngle": {
+          "type": "float", 
+          "description": "Cone Inner Angle",
+          "default": 360.0
+        },
+        "coneOuterAngle": {
+          "type": "float", 
+          "description": "Cone Outer Angle",
+          "default": 360.0
+        },
+        "coneOuterGain": {
+          "type": "float", 
+          "description": "Cone Outer Gain",
+          "default": 0.0
+        }
+      }
+    },
     "nav-mesh": {
       "category": "Scene",
       "node": true,

--- a/default-config.json
+++ b/default-config.json
@@ -35,11 +35,71 @@
     }
   },
   "components": {
+    "background": {
+      "category": "Root",
+      "node": true,
+      "properties": {
+        "color": { "type": "color", "default": "#aaaaaa" }
+      }
+    },
+    "fog": {
+      "category": "Root",
+      "node": true,
+      "properties": {
+        "type": {
+          "type": "enum",
+          "description": "Fog Type",
+          "items": [ 
+            [ "disabled", "No fog", "No fog effect will be applied" ],
+            [ "linear", "Linear fog", "Fog effect will increase linearly with distance" ],
+            [ "exponential", "Exponential fog", "Fog effect will increase exponentially with distance" ]
+          ]
+        },
+        "color": { "type": "color", "default": "#ffffff" },
+        "near": { "type": "float", "default": 1, "description": "Fog Near Distance (linear only)" },
+        "far": { "type": "float", "default": 100, "description": "Fog Far Distance (linear only)" },
+        "density": { "type": "float", "default": 0.1, "description": "Fog Density (exponential only)" }
+      }
+    },
+    "audio-settings": {
+      "category": "Root",
+      "node": true,
+      "properties": {
+        "avatarDistanceModel": {
+          "type": "enum",
+          "description": "Avatar Distance Model",
+          "items": [ 
+            [ "inverse", "Inverse drop off (inverse)", "Volume will decrease inversely with distance" ],
+            [ "linear", "Linear drop off (linear)", "Volume will decrease linearly with distance" ],
+            [ "exponential", "Exponential drop off (exponential)", "Volume will decrease expoentially with distance" ]
+          ]
+        },
+        "avatarRolloffFactor": { "type": "float", "default": 2, "description": "Avatar Rolloff Factor" },
+        "avatarRefDistance": { "type": "float", "default": 1, "unit": "LENGTH", "description": " Avatar Ref Distance" },
+        "avatarMaxDistance": { "type": "float", "default": 10000, "unit": "LENGTH","description": "Avatar Max Distance" },
+        "mediaVolume": { "type": "float", "default": 0.5, "description": "Media Volume" },
+        "mediaDistanceModel": {
+          "type": "enum",
+          "description": "Media Distance Model",
+          "items": [ 
+            [ "inverse", "Inverse drop off (inverse)", "Volume will decrease inversely with distance" ],
+            [ "linear", "Linear drop off (linear)", "Volume will decrease linearly with distance" ],
+            [ "exponential", "Exponential drop off (exponential)", "Volume will decrease expoentially with distance" ]
+          ]
+        },
+        "mediaRolloffFactor": { "type": "float", "default": 2, "description": "Media Rolloff Factor" },
+        "mediaRefDistance": { "type": "float", "default": 1, "unit": "LENGTH","description": " Media Ref Distance" },
+        "mediaMaxDistance": { "type": "float", "default": 10000, "unit": "LENGTH","description": "Media Max Distance" },
+        "mediaConeInnerAngle": { "type": "float", "default": 360, "description": "Media Cone Inner Angle" },
+        "mediaConeOuterAngle": { "type": "float", "default": 0, "description": "Media Cone Outer Angle" },
+        "mediaConeOuterGain": { "type": "float", "default": 0, "description": "Media Cone Outer Gain" }
+      }
+    },
     "visible": {
       "category": "Scene",
       "node": true,
       "properties": {
-        "visible": { "type": "bool", "default": true }
+        "type": { "type": "bool", "default": true }
       }
     },
     "waypoint": {

--- a/default-config.json
+++ b/default-config.json
@@ -35,6 +35,13 @@
     }
   },
   "components": {
+    "visible": {
+      "category": "Scene",
+      "node": true,
+      "properties": {
+      "visible": { "type": "bool", "default": true }
+      }
+    },
     "waypoint": {
       "category": "Scene",
       "node": true,


### PR DESCRIPTION
All of the components that can be added to the root of a Hubs scene. I added them to a new category called "Root" to differentiate them from components that can be added to arbitrary nodes, but I couldn't see an easy way to enforce this restriction.