### PR TITLE
Scene-level components

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -112,6 +112,16 @@ class glTF2ExportUserExtension:
             gltf2_object.asset.extras = {}
         gltf2_object.asset.extras["HUBS_blenderExporterVersion"] = get_version_string()
 
+    def gather_scene_hook(self, gltf2_object, blender_scene, export_settings):
+        if not self.properties.enabled: return
+
+        # Don't include hubs component data again in extras, even if "include custom properties" is enabled
+        if gltf2_object.extras:
+            for key in list(gltf2_object.extras):
+                if key.startswith("hubs_"): del gltf2_object.extras[key]
+
+        self.add_hubs_components(gltf2_object, blender_scene, export_settings)
+
     def gather_node_hook(self, gltf2_object, blender_object, export_settings):
         if not self.properties.enabled: return
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,5 @@
 import bpy
+import uuid
 
 from . import settings
 from . import components
@@ -148,6 +149,7 @@ class glTF2ExportUserExtension:
 
         if component_list.items:
             extension_name = hubs_config["gltfExtensionName"]
+            is_networked = False
             component_data = {}
 
             for component_item in component_list.items:
@@ -157,6 +159,13 @@ class glTF2ExportUserExtension:
                 component_class_name = component_class.__name__
                 component = getattr(blender_object, component_class_name)
                 component_data[component_name] = gather_properties(export_settings, blender_object, component, component_definition, hubs_config)
+                is_networked |= component_name in ("link", "image", "audio", "video")
+
+            # NAF-supported media require a network ID
+            if is_networked:
+                component_data["networked"] = {
+                    "id" : str(uuid.uuid4()).upper()
+                }
 
             if gltf2_object.extensions is None:
                 gltf2_object.extensions = {}

--- a/default-config.json
+++ b/default-config.json
@@ -36,34 +36,36 @@
   },
   "components": {
     "background": {
-      "category": "Root",
-      "node": true,
+      "category": "Scene",
+      "scene": true,
+      "node": false,
       "properties": {
         "color": { "type": "color", "default": "#aaaaaa" }
       }
     },
     "fog": {
-      "category": "Root",
-      "node": true,
+      "category": "Scene",
+      "scene": true,
+      "node": false,
       "properties": {
         "type": {
           "type": "enum",
           "description": "Fog Type",
           "items": [ 
-            [ "disabled", "No fog", "No fog effect will be applied" ],
             [ "linear", "Linear fog", "Fog effect will increase linearly with distance" ],
             [ "exponential", "Exponential fog", "Fog effect will increase exponentially with distance" ]
           ]
         },
         "color": { "type": "color", "default": "#ffffff" },
-        "near": { "type": "float", "default": 1, "description": "Fog Near Distance (linear only)" },
-        "far": { "type": "float", "default": 100, "description": "Fog Far Distance (linear only)" },
+        "near": { "type": "float", "default": 1.0, "description": "Fog Near Distance (linear only)" },
+        "far": { "type": "float", "default": 100.0, "description": "Fog Far Distance (linear only)" },
         "density": { "type": "float", "default": 0.1, "description": "Fog Density (exponential only)" }
       }
     },
     "audio-settings": {
-      "category": "Root",
-      "node": true,
+      "category": "Scene",
+      "scene": true,
+      "node": false,
       "properties": {
         "avatarDistanceModel": {
           "type": "enum",
@@ -74,9 +76,9 @@
             [ "exponential", "Exponential drop off (exponential)", "Volume will decrease expoentially with distance" ]
           ]
         },
-        "avatarRolloffFactor": { "type": "float", "default": 2, "description": "Avatar Rolloff Factor" },
-        "avatarRefDistance": { "type": "float", "default": 1, "unit": "LENGTH", "description": " Avatar Ref Distance" },
-        "avatarMaxDistance": { "type": "float", "default": 10000, "unit": "LENGTH","description": "Avatar Max Distance" },
+        "avatarRolloffFactor": { "type": "float", "default": 2.0, "description": "Avatar Rolloff Factor" },
+        "avatarRefDistance": { "type": "float", "default": 1.0, "unit": "LENGTH", "description": " Avatar Ref Distance" },
+        "avatarMaxDistance": { "type": "float", "default": 10000.0, "unit": "LENGTH","description": "Avatar Max Distance" },
         "mediaVolume": { "type": "float", "default": 0.5, "description": "Media Volume" },
         "mediaDistanceModel": {
           "type": "enum",
@@ -87,19 +89,19 @@
             [ "exponential", "Exponential drop off (exponential)", "Volume will decrease expoentially with distance" ]
           ]
         },
-        "mediaRolloffFactor": { "type": "float", "default": 2, "description": "Media Rolloff Factor" },
-        "mediaRefDistance": { "type": "float", "default": 1, "unit": "LENGTH","description": " Media Ref Distance" },
-        "mediaMaxDistance": { "type": "float", "default": 10000, "unit": "LENGTH","description": "Media Max Distance" },
-        "mediaConeInnerAngle": { "type": "float", "default": 360, "description": "Media Cone Inner Angle" },
-        "mediaConeOuterAngle": { "type": "float", "default": 0, "description": "Media Cone Outer Angle" },
-        "mediaConeOuterGain": { "type": "float", "default": 0, "description": "Media Cone Outer Gain" }
+        "mediaRolloffFactor": { "type": "float", "default": 2.0, "description": "Media Rolloff Factor" },
+        "mediaRefDistance": { "type": "float", "default": 1.0, "unit": "LENGTH","description": " Media Ref Distance" },
+        "mediaMaxDistance": { "type": "float", "default": 10000.0, "unit": "LENGTH","description": "Media Max Distance" },
+        "mediaConeInnerAngle": { "type": "float", "default": 360.0, "description": "Media Cone Inner Angle" },
+        "mediaConeOuterAngle": { "type": "float", "default": 0.0, "description": "Media Cone Outer Angle" },
+        "mediaConeOuterGain": { "type": "float", "default": 0.0, "description": "Media Cone Outer Gain" }
       }
     },
     "visible": {
       "category": "Scene",
       "node": true,
       "properties": {
-        "type": { "type": "bool", "default": true }
+        "visible": { "type": "bool", "default": true }
       }
     },
     "waypoint": {

--- a/default-config.json
+++ b/default-config.json
@@ -74,6 +74,214 @@
       "invadingOpacity": { "type": "float", "default": 0.3 }
       }
     },
+    "link": {
+      "category": "Scene",
+      "node": true,
+      "properties": {
+        "href": {
+          "type": "string",
+          "description": "URL"
+        }
+      }
+    },
+    "image": {
+      "category": "Scene",
+      "node": true,
+      "properties": {
+        "src": {
+          "type": "string",
+          "description": "Image URL"
+        },
+        "controls": {
+          "type": "bool", 
+          "description": "Controls",
+          "default": true
+        },
+        "alphaMode": {
+          "type": "enum",
+          "description": "Transparency Mode",
+          "items": [ 
+            [ "opaque", "No transparency (opaque)", "Alpha channel will be ignored" ],
+            [ "blend", "Gradual transparency (blend)", "Alpha channel will be applied" ],
+            [ "mask", "Binary transparency (mask)", "Alpha channel will be used as a threshold between opaque and transparent pixels" ]
+          ]
+        },
+        "projection": {
+          "type": "enum",
+          "description": "Projection",
+          "items": [ 
+            [ "flat", "2D image (flat)", "Image will be shown on a 2D surface" ],
+            [ "360-equirectangular", "Spherical (360-equirectangular)", "Image will be shown on a sphere" ]
+          ]
+        }
+      }
+    },
+    "audio": {
+      "category": "Scene",
+      "node": true,
+      "properties": {
+        "src": {
+          "type": "string",
+          "description": "Audio URL"
+        },
+        "autoPlay": {
+          "type": "bool", 
+          "description": "Auto Play",
+          "default": true
+        },
+        "controls": {
+          "type": "bool", 
+          "description": "Controls",
+          "default": true
+        },
+        "loop": {
+          "type": "bool", 
+          "description": "Loop",
+          "default": true
+        },
+        "audioType": {
+          "type": "enum",
+          "description": "Audio Type",
+          "items": [ 
+            [ "pannernode", "Positional audio (pannernode)", "Volume will change depending on the listener's position relative to the source" ],
+            [ "stereo", "Background audio (stereo)", "Volume will be independent of the listener's position" ]
+          ]
+        },
+        "volume": {
+          "type": "float", 
+          "description": "Volume",
+          "default": 0.5
+        },
+        "distanceModel": {
+          "type": "enum",
+          "description": "Distance Model",
+          "items": [ 
+            [ "inverse", "Inverse drop off (inverse)", "Volume will decrease inversely with distance" ],
+            [ "linear", "Linear drop off (linear)", "Volume will decrease linearly with distance" ],
+            [ "exponential", "Exponential drop off (exponential)", "Volume will decrease expoentially with distance" ]
+          ]
+        },
+        "rolloffFactor": {
+          "type": "float", 
+          "description": "Rolloff Factor",
+          "default": 1.0
+        },
+        "refDistance": {
+          "type": "float", 
+          "description": "Ref Distance",
+          "unit": "LENGTH",
+          "default": 1.0
+        },
+        "maxDistance": {
+          "type": "float", 
+          "description": "Max Distance",
+          "unit": "LENGTH",
+          "default": 10000.0
+        },
+        "coneInnerAngle": {
+          "type": "float", 
+          "description": "Cone Inner Angle",
+          "default": 360.0
+        },
+        "coneOuterAngle": {
+          "type": "float", 
+          "description": "Cone Outer Angle",
+          "default": 360.0
+        },
+        "coneOuterGain": {
+          "type": "float", 
+          "description": "Cone Outer Gain",
+          "default": 0.0
+        }
+      }
+    },
+    "video": {
+      "category": "Scene",
+      "node": true,
+      "properties": {
+        "src": {
+          "type": "string",
+          "description": "Video URL"
+        },
+        "projection": {
+          "type": "enum",
+          "description": "Projection",
+          "items": [ 
+            [ "flat", "2D image (flat)", "Image will be shown on a 2D surface" ],
+            [ "360-equirectangular", "Spherical (360-equirectangular)", "Image will be shown on a sphere" ]
+          ]
+        },
+        "autoPlay": {
+          "type": "bool", 
+          "description": "Auto Play",
+          "default": true
+        },
+        "controls": {
+          "type": "bool", 
+          "description": "Controls",
+          "default": true
+        },
+        "loop": {
+          "type": "bool", 
+          "description": "Loop",
+          "default": true
+        },
+        "audioType": {
+          "type": "enum",
+          "description": "Audio Type",
+          "items": [ 
+            [ "pannernode", "Positional audio (pannernode)", "Volume will change depending on the listener's position relative to the source" ],
+            [ "stereo", "Background audio (stereo)", "Volume will be independent of the listener's position" ]
+          ]
+        },
+        "volume": {
+          "type": "float", 
+          "description": "Volume",
+          "default": 0.5
+        },
+        "distanceModel": {
+          "type": "enum",
+          "description": "Distance Model",
+          "items": [ 
+            [ "inverse", "Inverse drop off (inverse)", "Volume will decrease inversely with distance" ],
+            [ "linear", "Linear drop off (linear)", "Volume will decrease linearly with distance" ],
+            [ "exponential", "Exponential drop off (exponential)", "Volume will decrease expoentially with distance" ]
+          ]
+        },
+        "rolloffFactor": {
+          "type": "float", 
+          "description": "Rolloff Factor",
+          "default": 1.0
+        },
+        "refDistance": {
+          "type": "float", 
+          "description": "Ref Distance",
+          "unit": "LENGTH",
+          "default": 1.0
+        },
+        "maxDistance": {
+          "type": "float", 
+          "description": "Max Distance",
+          "unit": "LENGTH",
+          "default": 10000.0
+        },
+        "coneInnerAngle": {
+          "type": "float", 
+          "description": "Cone Inner Angle",
+          "default": 360.0
+        },
+        "coneOuterAngle": {
+          "type": "float", 
+          "description": "Cone Outer Angle",
+          "default": 360.0
+        },
+        "coneOuterGain": {
+          "type": "float", 
+          "description": "Cone Outer Gain",
+          "default": 0.0
+        }
+      }
+    },
     "nav-mesh": {
       "category": "Scene",
       "node": true,

--- a/default-config.json
+++ b/default-config.json
@@ -35,11 +35,71 @@
     }
   },
   "components": {
+    "background": {
+      "category": "Root",
+      "node": true,
+      "properties": {
+        "color": { "type": "color", "default": "#aaaaaa" }
+      }
+    },
+    "fog": {
+      "category": "Root",
+      "node": true,
+      "properties": {
+        "type": {
+          "type": "enum",
+          "description": "Fog Type",
+          "items": [ 
+            [ "disabled", "No fog", "No fog effect will be applied" ],
+            [ "linear", "Linear fog", "Fog effect will increase linearly with distance" ],
+            [ "exponential", "Exponential fog", "Fog effect will increase exponentially with distance" ]
+          ]
+        },
+        "color": { "type": "color", "default": "#ffffff" },
+        "near": { "type": "float", "default": 1, "description": "Fog Near Distance (linear only)" },
+        "far": { "type": "float", "default": 100, "description": "Fog Far Distance (linear only)" },
+        "density": { "type": "float", "default": 0.1, "description": "Fog Density (exponential only)" }
+      }
+    },
+    "audio-settings": {
+      "category": "Root",
+      "node": true,
+      "properties": {
+        "avatarDistanceModel": {
+          "type": "enum",
+          "description": "Avatar Distance Model",
+          "items": [ 
+            [ "inverse", "Inverse drop off (inverse)", "Volume will decrease inversely with distance" ],
+            [ "linear", "Linear drop off (linear)", "Volume will decrease linearly with distance" ],
+            [ "exponential", "Exponential drop off (exponential)", "Volume will decrease expoentially with distance" ]
+          ]
+        },
+        "avatarRolloffFactor": { "type": "float", "default": 2, "description": "Avatar Rolloff Factor" },
+        "avatarRefDistance": { "type": "float", "default": 1, "unit": "LENGTH", "description": " Avatar Ref Distance" },
+        "avatarMaxDistance": { "type": "float", "default": 10000, "unit": "LENGTH","description": "Avatar Max Distance" },
+        "mediaVolume": { "type": "float", "default": 0.5, "description": "Media Volume" },
+        "mediaDistanceModel": {
+          "type": "enum",
+          "description": "Media Distance Model",
+          "items": [ 
+            [ "inverse", "Inverse drop off (inverse)", "Volume will decrease inversely with distance" ],
+            [ "linear", "Linear drop off (linear)", "Volume will decrease linearly with distance" ],
+            [ "exponential", "Exponential drop off (exponential)", "Volume will decrease expoentially with distance" ]
+          ]
+        },
+        "mediaRolloffFactor": { "type": "float", "default": 2, "description": "Media Rolloff Factor" },
+        "mediaRefDistance": { "type": "float", "default": 1, "unit": "LENGTH","description": " Media Ref Distance" },
+        "mediaMaxDistance": { "type": "float", "default": 10000, "unit": "LENGTH","description": "Media Max Distance" },
+        "mediaConeInnerAngle": { "type": "float", "default": 360, "description": "Media Cone Inner Angle" },
+        "mediaConeOuterAngle": { "type": "float", "default": 0, "description": "Media Cone Outer Angle" },
+        "mediaConeOuterGain": { "type": "float", "default": 0, "description": "Media Cone Outer Gain" }
+      }
+    },
     "visible": {
       "category": "Scene",
       "node": true,
       "properties": {
-        "visible": { "type": "bool", "default": true }
+        "type": { "type": "bool", "default": true }
       }
     },
     "waypoint": {

--- a/default-config.json
+++ b/default-config.json
@@ -35,6 +35,13 @@
     }
   },
   "components": {
+    "visible": {
+      "category": "Scene",
+      "node": true,
+      "properties": {
+      "visible": { "type": "bool", "default": true }
+      }
+    },
     "waypoint": {
       "category": "Scene",
       "node": true,

--- a/gather_properties.py
+++ b/gather_properties.py
@@ -34,6 +34,8 @@ def gather_property(export_settings, blender_object, target, property_name, prop
         return gather_array_property(export_settings, blender_object, target, property_name, property_definition, hubs_config)
     elif property_type in ['vec2', 'vec3', 'vec4', 'ivec2', 'ivec3', 'ivec4']:
         return gather_vec_property(export_settings, blender_object, target, property_name, property_definition, hubs_config)
+    elif property_type == 'color':
+        return gather_color_property(export_settings, blender_object, target, property_name, property_definition, hubs_config)
     else:
         return gltf2_blender_extras.__to_json_compatible(getattr(target, property_name))
 
@@ -123,6 +125,11 @@ def gather_collections_property(export_settings, blender_object, target, propert
             filtered_collection_names.append(collection.name)
 
     return filtered_collection_names
+
+def gather_color_property(export_settings, blender_object, target, property_name, property_definition, hubs_config):
+    # Convert RGB color array to hex. Blender stores colors in linear space and GLTF color factors are typically in linear space
+    c = getattr(target, property_name)
+    return "#{0:02x}{1:02x}{2:02x}".format(max(0, min(int(c[0] * 256.0), 255)), max(0, min(int(c[1] * 256.0), 255)), max(0, min(int(c[2] * 256.0), 255)))
 
 @cached
 def gather_lightmap_texture_info(blender_material, export_settings):


### PR DESCRIPTION
I've added support for the three components that can be defined at the scene level in Spoke:

- Background color
- Fog settings
- Default audio settings (avatars and media)

Colors in Blender appear to be defined in linear space and the raw linear values are shown in the RGB part of the color editor. However the hex values in the color editor are in a gamma-corrected space. I have assumed that the color fields for the background and fog Hubs components should be linear colors (I think this is typical of single value GLTF colors) and so the slightly unexpected consequence is that if you paste a hex color into Blender, you won't necessary get the same hex codes out again in the GLTF file. This might need some scrutiny as my understanding of color spaces is limited.