### PR TITLE
Update to Blender 2.91

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -11,8 +11,8 @@ bl_info = {
     "name" : "Hubs Blender Exporter",
     "author" : "MozillaReality",
     "description" : "Tools for developing GLTF assets for Mozilla Hubs",
-    "blender" : (2, 83, 0),
-    "version" : (0, 0, 4),
+    "blender" : (2, 91, 0),
+    "version" : (0, 0, 5),
     "location" : "",
     "wiki_url": "https://github.com/MozillaReality/hubs-blender-exporter",
     "tracker_url": "https://github.com/MozillaReality/hubs-blender-exporter/issues",
@@ -34,19 +34,9 @@ def patched_gather_gltf(exporter, export_settings):
     export_user_extensions('hubs_gather_gltf_hook', export_settings, exporter._GlTF2Exporter__gltf)
     exporter._GlTF2Exporter__traverse(exporter._GlTF2Exporter__gltf.extensions)
 
-# Monkey patch to add gather_joint_hook, has been merged upstrea for Blender 2.9 without the hubs_ prefix and should be removed once that ships
-from io_scene_gltf2.blender.exp import gltf2_blender_gather_joints
-from io_scene_gltf2.io.exp.gltf2_io_user_extensions import export_user_extensions
-orig_gather_joint = gltf2_blender_gather_joints.gather_joint
-def patched_gather_joint(blender_object, blender_bone, export_settings):
-    node = orig_gather_joint(blender_object, blender_bone, export_settings)
-    export_user_extensions('hubs_gather_joint_hook', export_settings, node, blender_bone)
-    return node
-
-
 def register():
     gltf2_blender_export.__gather_gltf = patched_gather_gltf
-    gltf2_blender_gather_joints.gather_joint = patched_gather_joint
+
 
     components.register()
     settings.register()
@@ -56,7 +46,6 @@ def register():
 
 def unregister():
     gltf2_blender_export.__gather_gltf = orig_gather_gltf
-    gltf2_blender_gather_joints.gather_joint = orig_gather_joint
 
     components.unregister()
     settings.unregister()
@@ -134,10 +123,11 @@ class glTF2ExportUserExtension:
                     extension=lightmap_texture_info,
                     required=False,
                 )
+    def gather_material_unlit_hook(self, gltf2_object, blender_material, export_settings):
+        self.gather_material_hook(gltf2_object, blender_material, export_settings)
 
-    def hubs_gather_joint_hook(self, gltf2_object, blender_pose_bone, export_settings):
+    def gather_joint_hook(self, gltf2_object, blender_pose_bone, export_settings):
         if not self.properties.enabled: return
-
         self.add_hubs_components(gltf2_object, blender_pose_bone.bone, export_settings)
 
     def add_hubs_components(self, gltf2_object, blender_object, export_settings):

--- a/gather_properties.py
+++ b/gather_properties.py
@@ -6,11 +6,7 @@ from io_scene_gltf2.blender.exp import gltf2_blender_gather_materials, gltf2_ble
 from io_scene_gltf2.blender.exp.gltf2_blender_image import ExportImage
 from io_scene_gltf2.blender.com import gltf2_blender_extras
 from io_scene_gltf2.blender.exp.gltf2_blender_gather_cache import cached
-from io_scene_gltf2.blender.exp.gltf2_blender_gather_texture_info import (
-    __filter_texture_info,
-    __gather_index,
-    __gather_tex_coord,
-)
+from io_scene_gltf2.blender.exp.gltf2_blender_gather_texture_info import gather_texture_info
 from .nodes import MozLightmapNode
 
 def gather_properties(export_settings, blender_object, target, type_definition, hubs_config):
@@ -131,19 +127,16 @@ def gather_lightmap_texture_info(blender_material, export_settings):
 
     if not lightmap_node: return
 
-    texture = lightmap_node.inputs.get("Lightmap")
+    texture_socket = lightmap_node.inputs.get("Lightmap")
     intensity = lightmap_node.intensity
 
-    if not __filter_texture_info((texture,), export_settings):
-        return None
+    texture_info = gather_texture_info(texture_socket, (texture_socket,), export_settings)
+    if not texture_info: return
 
-    texture_info = {
+    return {
         "intensity": intensity,
-        "index": __gather_index((texture,), export_settings),
-        "texCoord": __gather_tex_coord((texture,), export_settings)
+        'extensions': texture_info.extensions,
+        'extras': texture_info.extras,
+        "index": texture_info.index,
+        "texCoord": texture_info.tex_coord
     }
-
-    if texture_info["index"] is None:
-        return None
-
-    return texture_info


### PR DESCRIPTION
- Fix lightmap not exporting on unlit materials
- Remove some hacks that were in place that are no longer needed with the latest GLTF exporter