### PR TITLE
Add video-texture-source component.

### DIFF
--- a/components.py
+++ b/components.py
@@ -1,7 +1,8 @@
 import bpy
 from bpy.props import IntVectorProperty, BoolProperty, FloatProperty, StringProperty, EnumProperty
 from bpy.props import PointerProperty, FloatVectorProperty, CollectionProperty, IntProperty
-from bpy.types import PropertyGroup, Material, Image
+from bpy.types import PropertyGroup, Material, Image, Object
+from . import components
 
 class StringArrayValueProperty(PropertyGroup):
     value: StringProperty(name="value", default="")
@@ -192,6 +193,16 @@ def define_property(class_name, property_name, property_definition, hubs_context
             description=property_definition.get("description") or "",
             type=Material
         )
+    elif property_type == 'object':
+        def filter_on_component(self, o):
+            return components.has_components(o, ["video-texture-source"])
+
+        return PointerProperty(
+            name=property_name,
+            description=property_definition.get("description") or "",
+            type=Object,
+            poll=filter_on_component
+        )
     elif property_type == 'image':
         return PointerProperty(
             name=property_name,
@@ -289,6 +300,13 @@ def remove_component(obj, component_name):
 def has_component(obj, component_name):
     items = obj.hubs_component_list.items
     return component_name in items
+
+def has_components(obj, component_names):
+    items = obj.hubs_component_list.items
+    for name in component_names:
+        print(obj.name, items, name)
+        if name not in items: return False
+    return True
 
 def register():
     bpy.utils.register_class(StringArrayValueProperty)

--- a/components.py
+++ b/components.py
@@ -193,7 +193,7 @@ def define_property(class_name, property_name, property_definition, hubs_context
             description=property_definition.get("description") or "",
             type=Material
         )
-    elif property_type == 'object':
+    elif property_type == 'nodeRef':
         def filter_on_component(self, o):
             return components.has_components(o, ["video-texture-source"])
 
@@ -304,7 +304,6 @@ def has_component(obj, component_name):
 def has_components(obj, component_names):
     items = obj.hubs_component_list.items
     for name in component_names:
-        print(obj.name, items, name)
         if name not in items: return False
     return True
 

--- a/components.py
+++ b/components.py
@@ -100,56 +100,57 @@ def define_type(type_name, hubs_context):
 
 def define_property(class_name, property_name, property_definition, hubs_context):
     property_type = property_definition['type']
+    display_name = property_definition.get("label", property_name)
 
     if property_type == 'int':
         return IntProperty(
-            name=property_name,
+            name=display_name,
             description=property_definition.get("description") or "",
             subtype=property_definition.get("subType") or "NONE",
         )
     elif property_type == 'float':
         return FloatProperty(
-            name=property_name,
+            name=display_name,
             description=property_definition.get("description") or "",
             subtype=property_definition.get("subType") or "NONE",
             unit=property_definition.get("unit") or "NONE"
         )
     elif property_type == 'bool':
         return BoolProperty(
-            name=property_name,
+            name=display_name,
             description=property_definition.get("description") or "",
             subtype=property_definition.get("subType") or "NONE"
         )
     elif property_type == 'string':
         return StringProperty(
-            name=property_name,
+            name=display_name,
             description=property_definition.get("description") or "",
             subtype=property_definition.get("subType") or "NONE"
         )
     elif property_type == 'ivec2':
         return IntVectorProperty(
-            name=property_name,
+            name=display_name,
             description=property_definition.get("description") or "",
             subtype=property_definition.get("subType") or "NONE",
             size=2
         )
     elif property_type == 'ivec3':
         return IntVectorProperty(
-            name=property_name,
+            name=display_name,
             description=property_definition.get("description") or "",
             subtype=property_definition.get("subType") or "NONE",
             size=3
         )
     elif property_type == 'ivec4':
         return IntVectorProperty(
-            name=property_name,
+            name=display_name,
             description=property_definition.get("description") or "",
             subtype=property_definition.get("subType") or "NONE",
             size=4
         )
     elif property_type == 'vec2':
         return FloatVectorProperty(
-            name=property_name,
+            name=display_name,
             description=property_definition.get("description") or "",
             subtype=property_definition.get("subType") or "NONE",
             unit=property_definition.get("unit") or "NONE",
@@ -157,7 +158,7 @@ def define_property(class_name, property_name, property_definition, hubs_context
         )
     elif property_type == 'vec3':
         return FloatVectorProperty(
-            name=property_name,
+            name=display_name,
             description=property_definition.get("description") or "",
             subtype=property_definition.get("subType") or "NONE",
             unit=property_definition.get("unit") or "NONE",
@@ -165,7 +166,7 @@ def define_property(class_name, property_name, property_definition, hubs_context
         )
     elif property_type == 'vec4':
         return FloatVectorProperty(
-            name=property_name,
+            name=display_name,
             description=property_definition.get("description") or "",
             subtype=property_definition.get("subType") or "NONE",
             unit=property_definition.get("unit") or "NONE",
@@ -173,13 +174,13 @@ def define_property(class_name, property_name, property_definition, hubs_context
         )
     elif property_type == 'enum':
         return EnumProperty(
-            name=property_name,
+            name=display_name,
             description=property_definition.get("description") or "",
             items=[tuple(i) for i in property_definition.get("items")]
         )
     elif property_type == 'color':
         return FloatVectorProperty(
-            name=property_name,
+            name=display_name,
             description=property_definition.get("description") or "",
             subtype='COLOR',
             default=(1.0, 1.0, 1.0, 1.0),
@@ -189,7 +190,7 @@ def define_property(class_name, property_name, property_definition, hubs_context
         )
     elif property_type == 'material':
         return PointerProperty(
-            name=property_name,
+            name=display_name,
             description=property_definition.get("description") or "",
             type=Material
         )
@@ -200,14 +201,14 @@ def define_property(class_name, property_name, property_definition, hubs_context
             return components.has_components(o, required_components)
 
         return PointerProperty(
-            name=property_name,
+            name=display_name,
             description=property_definition.get("description") or "",
             type=Object,
             poll=filter_on_component
         )
     elif property_type == 'image':
         return PointerProperty(
-            name=property_name,
+            name=display_name,
             description=property_definition.get("description") or "",
             type=Image
         )
@@ -229,7 +230,7 @@ def define_property(class_name, property_name, property_definition, hubs_context
                 array_type, property_name, class_name))
 
         return CollectionProperty(
-            name=property_name,
+            name=display_name,
             description=property_definition.get("description") or "",
             type=property_class
         )
@@ -241,7 +242,7 @@ def define_property(class_name, property_name, property_definition, hubs_context
                 property_type, property_name, class_name))
 
         return PointerProperty(
-            name=property_name,
+            name=display_name,
             description=property_definition.get("description") or "",
             type=property_class
         )

--- a/components.py
+++ b/components.py
@@ -194,8 +194,10 @@ def define_property(class_name, property_name, property_definition, hubs_context
             type=Material
         )
     elif property_type == 'nodeRef':
+        required_components = property_definition.get("hasComponents") or []
+
         def filter_on_component(self, o):
-            return components.has_components(o, ["video-texture-source"])
+            return components.has_components(o, required_components)
 
         return PointerProperty(
             name=property_name,

--- a/components.py
+++ b/components.py
@@ -292,6 +292,9 @@ def add_component(obj, component_name, hubs_config, registered_hubs_components):
                 for value in default_value:
                     item = arr.add()
                     item.value = value
+            elif property_type == "enum":
+                index = next(i for i, item in enumerate(property_definition["items"]) if item[0] == default_value)
+                component[property_name] = index
             else:
                 component[property_name] = default_value
 

--- a/default-config.json
+++ b/default-config.json
@@ -513,7 +513,7 @@
           "default": false
         },
         "src": {
-          "type": "object",
+          "type": "nodeRef",
           "hasComponents": ["video-texture-source"]
         }
       }

--- a/default-config.json
+++ b/default-config.json
@@ -111,7 +111,7 @@
         "color": {"type": "color"},
         "intensity": {"type": "float", "default": 1.0},
         "castShadow": { "type": "bool", "default": false },
-        "shadowMapResolution": {"type": "ivec2", "unit":"PIXEL", "default": {"x": 512, "y": 512}},
+        "shadowMapResolution": {"type": "ivec2", "unit":"PIXEL", "default": [512, 512]},
         "shadowBias": {"type": "float", "default": 0.0},
         "shadowRadius": {"type": "float", "default": 1.0}
       }
@@ -125,7 +125,7 @@
         "range": {"type": "float", "default": 0.0},
         "decay": {"type": "float", "default": 2.0},
         "castShadow": { "type": "bool", "default": false },
-        "shadowMapResolution": {"type": "ivec2", "unit":"PIXEL", "default": {"x": 512, "y": 512}},
+        "shadowMapResolution": {"type": "ivec2", "unit":"PIXEL", "default": [512, 512]},
         "shadowBias": {"type": "float", "default": 0.0},
         "shadowRadius": {"type": "float", "default": 1.0}
       }

--- a/default-config.json
+++ b/default-config.json
@@ -512,7 +512,7 @@
           "type": "bool",
           "default": false
         },
-        "src": {
+        "srcNode": {
           "type": "nodeRef",
           "hasComponents": ["video-texture-source"]
         }

--- a/default-config.json
+++ b/default-config.json
@@ -511,6 +511,10 @@
         "targetEmissiveMap": {
           "type": "bool",
           "default": false
+        },
+        "src": {
+          "type": "object",
+          "hasComponents": ["video-texture-source"]
         }
       }
     },
@@ -522,6 +526,14 @@
           "type": "bool",
           "default": false
         }
+      }
+    },
+    "video-texture-source": {
+      "category": "Scene",
+      "node": true,
+      "properties": {
+        "resolution": {"type": "ivec2", "unit":"PIXEL", "default": [1280, 720]},
+        "fps": {"type": "int", "default": 15}
       }
     }
   }

--- a/default-config.json
+++ b/default-config.json
@@ -505,14 +505,18 @@
       "material": true,
       "properties": {
         "targetBaseColorMap": {
+          "description": "Should the video texture override the base color map?",
           "type": "bool",
           "default": true
         },
         "targetEmissiveMap": {
+          "description": "Should the video texture override the emissive map?",
           "type": "bool",
           "default": false
         },
         "srcNode": {
+          "label": "Source",
+          "description": "Node with a vide-texture-source to pull video from",
           "type": "nodeRef",
           "hasComponents": ["video-texture-source"]
         }

--- a/gather_properties.py
+++ b/gather_properties.py
@@ -37,8 +37,8 @@ def gather_property(export_settings, blender_object, target, property_name, prop
         return gather_vec_property(export_settings, blender_object, target, property_name, property_definition, hubs_config)
     elif property_type == 'color':
         return gather_color_property(export_settings, blender_object, target, property_name, property_definition, hubs_config)
-    elif property_type == 'object':
-        return gather_object_property(export_settings, blender_object, target, property_name, property_definition, hubs_config)
+    elif property_type == 'nodeRef':
+        return gather_node_property(export_settings, blender_object, target, property_name, property_definition, hubs_config)
     else:
         return gltf2_blender_extras.__to_json_compatible(getattr(target, property_name))
 
@@ -59,7 +59,7 @@ def gather_array_property(export_settings, blender_object, target, property_name
     
     return value
 
-def gather_object_property(export_settings, blender_object, target, property_name, property_definition, hubs_config):
+def gather_node_property(export_settings, blender_object, target, property_name, property_definition, hubs_config):
     blender_object = getattr(target, property_name)
 
     if blender_object:

--- a/gather_properties.py
+++ b/gather_properties.py
@@ -63,15 +63,13 @@ def gather_node_property(export_settings, blender_object, target, property_name,
     blender_object = getattr(target, property_name)
 
     if blender_object:
-        o = gltf2_blender_gather_nodes.gather_node(
+        return gltf2_blender_gather_nodes.gather_node(
             blender_object,
             blender_object.library.name if blender_object.library else None,
             blender_object.users_scene[0],
             None,
             export_settings
         )
-        print(o)
-        return o
     else:
         return None
 

--- a/gather_properties.py
+++ b/gather_properties.py
@@ -2,7 +2,7 @@ import os
 import datetime
 import re
 import bpy
-from io_scene_gltf2.blender.exp import gltf2_blender_gather_materials, gltf2_blender_gather_image
+from io_scene_gltf2.blender.exp import gltf2_blender_gather_materials, gltf2_blender_gather_image, gltf2_blender_gather_nodes
 from io_scene_gltf2.blender.exp.gltf2_blender_image import ExportImage
 from io_scene_gltf2.blender.com import gltf2_blender_extras
 from io_scene_gltf2.blender.exp.gltf2_blender_gather_cache import cached
@@ -37,6 +37,8 @@ def gather_property(export_settings, blender_object, target, property_name, prop
         return gather_vec_property(export_settings, blender_object, target, property_name, property_definition, hubs_config)
     elif property_type == 'color':
         return gather_color_property(export_settings, blender_object, target, property_name, property_definition, hubs_config)
+    elif property_type == 'object':
+        return gather_object_property(export_settings, blender_object, target, property_name, property_definition, hubs_config)
     else:
         return gltf2_blender_extras.__to_json_compatible(getattr(target, property_name))
 
@@ -56,6 +58,22 @@ def gather_array_property(export_settings, blender_object, target, property_name
         value.append(item_value)
     
     return value
+
+def gather_object_property(export_settings, blender_object, target, property_name, property_definition, hubs_config):
+    blender_object = getattr(target, property_name)
+
+    if blender_object:
+        o = gltf2_blender_gather_nodes.gather_node(
+            blender_object,
+            blender_object.library.name if blender_object.library else None,
+            blender_object.users_scene[0],
+            None,
+            export_settings
+        )
+        print(o)
+        return o
+    else:
+        return None
 
 def gather_material_property(export_settings, blender_object, target, property_name, property_definition, hubs_config):
     blender_material = getattr(target, property_name)

--- a/gather_properties.py
+++ b/gather_properties.py
@@ -100,7 +100,7 @@ def gather_vec_property(export_settings, blender_object, target, property_name, 
         if len(vec) > 2:
             out["z"] = vec[2]
         if len(vec) > 3:
-            out["w"] = vec[4]
+            out["w"] = vec[3]
 
     return out
 


### PR DESCRIPTION
Adds a new component `video-texture-source` that can be placed on cameras. Also updates `video-texture-target` to have a `target` attribute, pointing at a node with `video-texture-source`. This required adding support for object pointer type in components json, which should prove pretty handy.

Incidentally also:
- Adds support for `nodeRef` type in component properties, allowing components to reference other nodes (optionally requiring specific components)
- Adds support for specifying a `label` for component properties, overriding the name displayed in the Blender UI
- Fixes handling of default values for enums
- Fixes exporting of vec4 properties

Hubs side support for these changes are in https://github.com/mozilla/hubs/pull/4126