### PR TITLE
Image property "controls" isn't required or used anywhere

### DIFF
--- a/default-config.json
+++ b/default-config.json
@@ -188,11 +188,6 @@
           "type": "string",
           "description": "Image URL"
         },
-        "controls": {
-          "type": "bool", 
-          "description": "Controls",
-          "default": true
-        },
         "alphaMode": {
           "type": "enum",
           "description": "Transparency Mode",


### PR DESCRIPTION
I can't see any code paths in Hubs client where this is actually used nor can I think of a scenario where it might be. The same property is surfaced in Spoke, but doesn't appear to do anything there either.

Happy to be wrong, but otherwise I suggest the property is removed to avoid future confusion.