### PR TITLE
Expose text element for labels and signs

### DIFF
--- a/default-config.json
+++ b/default-config.json
@@ -599,6 +599,15 @@
           "label": "Width",
           "default": 1.0
         },
+        "wrapCount": {
+          "type": "float",
+          "label": "Wrap Count",
+          "default": 40
+        },
+        "wrapPixels": {
+          "type": "float",
+          "label": "Wrap Pixels"
+        },
         "letterSpacing": {
           "type": "float",
           "label": "Letter Space",

--- a/default-config.json
+++ b/default-config.json
@@ -602,7 +602,7 @@
         "wrapCount": {
           "type": "float",
           "label": "Wrap Count",
-          "default": 40
+          "default": 40.0
         },
         "wrapPixels": {
           "type": "float",

--- a/default-config.json
+++ b/default-config.json
@@ -539,6 +539,91 @@
         "resolution": {"type": "ivec2", "unit":"PIXEL", "default": [1280, 720]},
         "fps": {"type": "int", "default": 15}
       }
+    },
+    "text": {
+      "category": "Elements",
+      "node": true,
+      "properties": {
+        "value": { 
+          "type": "string",
+          "label": "Text"
+        },
+        "align": {
+          "type": "enum",
+          "description": "Alignment",
+          "items": [ 
+            [ "left", "Left align", "Text will be aligned to the left" ],
+            [ "right", "Right align", "Text will be aligned to the right" ],
+            [ "center", "Center align", "Text will be centered" ]
+          ]
+        },
+        "baseline": {
+          "type": "enum",
+          "description": "Baseline",
+          "items": [ 
+            [ "top", "Top align", "Alignment will be with the top of the text" ],
+            [ "center", "Center align", "Alignment will be with the center of the text" ],
+            [ "bottom", "Bottom align", "Alignment will be with the bottom of the text" ]
+          ]
+        },
+        "side": {
+          "type": "enum",
+          "description": "Display Side",
+          "items": [ 
+            [ "front", "Show on front", "Text will be shown on the front (-Y)" ],
+            [ "back", "Show on back", "Text will be shown on the back (+Y)" ],
+            [ "double", "Show on both", "Text will be shown on both sides" ]
+          ]
+        },
+        "whiteSpace": {
+          "type": "enum",
+          "description": "White Space",
+          "items": [ 
+            [ "normal", "Normal", "Text will flow normally" ],
+            [ "pre", "Preserve", "White space will be preserved" ],
+            [ "nowrap", "No Wrapping", "Text will not be word-wrapped" ]
+          ]
+        },
+        "font": { 
+          "type": "string",
+          "label": "Font",
+          "default": "roboto"
+        },
+        "color": { 
+          "type": "color", 
+          "label": "Color",
+          "default": "#FFF" 
+        },
+        "width": {
+          "type": "float",
+          "label": "Width",
+          "default": 1.0
+        },
+        "letterSpacing": {
+          "type": "float",
+          "label": "Letter Space",
+          "default": 0
+        },
+        "lineHeight": {
+          "type": "float",
+          "label": "Line Height"
+        },
+        "opacity": {
+          "type": "float",
+          "label": "Opacity",
+          "default": 1.0
+        },
+        "xOffset": {
+          "type": "float",
+          "label": "X-Offset",
+          "default": 0.0
+        },
+        "zOffset": {
+          "type": "float",
+          "label": "Z-Offset",
+          "default": 0.001
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
The Hubs text component is very useful for quick and clear labels and signs. The resulting placement is slightly quirky, but the results are very good.

<img width="920" alt="Screenshot 2021-05-05 at 13 16 28" src="https://user-images.githubusercontent.com/303516/117139416-214f0280-ada4-11eb-8a5f-7c5b4573d859.png">

<img width="318" alt="Screenshot 2021-05-05 at 13 10 40" src="https://user-images.githubusercontent.com/303516/117138723-53139980-ada3-11eb-8ca6-be2a062de181.png">

[This archive](https://github.com/MozillaReality/hubs-blender-exporter/files/6426970/text-demo.zip) contains an example Blender file with text components and it also contains the exported GLB file for easy testing.

This PR relies on [this Hubs PR](https://github.com/mozilla/hubs/pull/4225) to allow the "text" component to be imported.