### PR TITLE
HDR Lightmap Exporting

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -12,7 +12,7 @@ bl_info = {
     "name" : "Hubs Blender Exporter",
     "author" : "MozillaReality",
     "description" : "Tools for developing GLTF assets for Mozilla Hubs",
-    "blender" : (2, 92, 0),
+    "blender" : (2, 93, 4),
     "version" : (0, 0, 10),
     "location" : "",
     "wiki_url": "https://github.com/MozillaReality/hubs-blender-exporter",

--- a/components.py
+++ b/components.py
@@ -122,8 +122,8 @@ def define_property(class_name, property_name, property_definition, hubs_context
             description=property_definition.get("description") or "",
             subtype=property_definition.get("subType") or "NONE",
             unit=property_definition.get("unit") or "NONE",
-            min=property_definition.get("min") if "min" in property_definition else -1e+38,
-            max=property_definition.get("max") if "max" in property_definition else +1e+38,
+            min=property_definition.get("min", float('-inf')),
+            max=property_definition.get("max", float('inf')),
         )
     elif property_type == 'bool':
         return BoolProperty(

--- a/components.py
+++ b/components.py
@@ -216,7 +216,7 @@ def define_property(class_name, property_name, property_definition, hubs_context
             type=Object,
             poll=filter_on_component
         )
-    elif property_type == 'image':
+    elif property_type == 'image' or property_type == 'texture':
         return PointerProperty(
             name=display_name,
             description=property_definition.get("description") or "",

--- a/default-config.json
+++ b/default-config.json
@@ -751,7 +751,7 @@
         },
         "rayleigh": {
           "type": "float",
-          "label": "Horizon Start",
+          "label": "Horizon End",
           "default": 2.0
         },
         "distance": {
@@ -905,6 +905,42 @@
       "properties": {
         "cast": { "type": "bool", "default": true },
         "receive": { "type": "bool", "default": true }
+      }
+    },
+    "environment-settings": {
+      "category": "Scene",
+      "node": false,
+      "scene": true,
+      "properties": {
+        "toneMapping": {
+          "type": "enum",
+          "description": "Tone Mapping",
+          "items": [
+            [ "NoToneMapping", "None", "No tone mapping." ],
+            [ "LinearToneMapping", "Linear", "Linear tone mapping" ],
+            [ "ReinhardToneMapping", "Reinhard", "Reinhard tone mapping" ],
+            [ "CineonToneMapping", "Cineon", "Cineon tone mapping" ],
+            [ "ACESFilmicToneMapping", "ACES Filmic", "ACES Filmic tone mapping" ]
+          ],
+          "default": "ACESFilmicToneMapping"
+        },
+        "toneMappingExposure": {
+          "label": "Exposure",
+          "type": "float",
+          "description": "Exposure level of tone mapping",
+          "default": 1.0
+        },
+        "backgroundColor": { "type": "color", "default": "#aaaaaa" },
+        "backgroundTexture": {
+          "type": "texture",
+          "label": "Backgorund Image",
+          "description": "An equirectangular image to use as the scene background"
+        },
+        "envMapTexture": {
+          "type": "texture",
+          "label": "EnvMap",
+          "description": "An equirectangular image to use as the default environment map for all objects"
+        }
       }
     }
   }

--- a/default-config.json
+++ b/default-config.json
@@ -44,14 +44,6 @@
     }
   },
   "components": {
-    "background": {
-      "category": "Scene",
-      "scene": true,
-      "node": false,
-      "properties": {
-        "color": { "type": "color", "default": "#aaaaaa" }
-      }
-    },
     "fog": {
       "category": "Scene",
       "scene": true,

--- a/gather_properties.py
+++ b/gather_properties.py
@@ -2,11 +2,11 @@ import os
 import datetime
 import re
 import bpy
-from io_scene_gltf2.blender.exp import gltf2_blender_gather_materials, gltf2_blender_gather_image, gltf2_blender_gather_nodes, gltf2_blender_gather_texture
-from io_scene_gltf2.blender.exp.gltf2_blender_image import ExportImage
+from io_scene_gltf2.blender.exp import gltf2_blender_gather_materials, gltf2_blender_gather_image, gltf2_blender_gather_nodes
 from io_scene_gltf2.blender.com import gltf2_blender_extras
 from io_scene_gltf2.blender.exp.gltf2_blender_gather_cache import cached
-from io_scene_gltf2.blender.exp.gltf2_blender_gather_texture_info import gather_texture_info
+from io_scene_gltf2.blender.exp import gltf2_blender_gather_texture_info, gltf2_blender_export_keys
+from io_scene_gltf2.io.com.gltf2_io import TextureInfo
 from .nodes import MozLightmapNode
 
 def gather_properties(export_settings, blender_object, target, type_definition, hubs_config):
@@ -110,28 +110,8 @@ def gather_vec_property(export_settings, blender_object, target, property_name, 
 
 def gather_image_property(export_settings, blender_object, target, property_name, property_definition, hubs_config):
     blender_image = getattr(target, property_name)
-
-    if blender_image:
-        image_data = ExportImage.from_blender_image(blender_image)
-        if image_data.empty():
-            return None
-
-        mime_type = gltf2_blender_gather_image.__gather_mime_type((), image_data, export_settings)
-        name = gltf2_blender_gather_image.__gather_name(image_data, export_settings)
-
-        uri = gltf2_blender_gather_image.__gather_uri(image_data, mime_type, name, export_settings)
-        buffer_view = gltf2_blender_gather_image.__gather_buffer_view(image_data, mime_type, name, export_settings)
-
-        image = gltf2_blender_gather_image.__make_image(
-            buffer_view,
-            None,
-            None,
-            mime_type,
-            name,
-            uri,
-            export_settings
-        )
-
+    image = gather_image(blender_image, export_settings)
+    if image:
         return {
             "__mhc_link_type": "image",
             "index": image
@@ -139,44 +119,149 @@ def gather_image_property(export_settings, blender_object, target, property_name
     else:
         return None
 
+def gather_texture_property(export_settings, blender_object, target, property_name, property_definition, hubs_config):
+    blender_image = getattr(target, property_name)
+    texture = gather_texture(blender_image, export_settings)
+    if texture:
+        return {
+            "__mhc_link_type": "texture",
+            "index": texture
+        }
+    else:
+        return None
+
+def gather_collections_property(export_settings, blender_object, target, property_name, property_definition, hubs_config):
+    filtered_collection_names = []
+
+    collection_prefix_regex = None
+
+    if 'collectionPrefix' in property_definition:
+        collection_prefix = property_definition['collectionPrefix']
+        collection_prefix_regex = re.compile(r'^' + collection_prefix)
+
+    for collection in blender_object.users_collection:
+        if collection_prefix_regex and collection_prefix_regex.match(collection.name):
+            new_name = collection_prefix_regex.sub("", collection.name)
+            filtered_collection_names.append(new_name)
+        elif not collection_prefix_regex:
+            filtered_collection_names.append(collection.name)
+
+    return filtered_collection_names
+
+def gather_color_property(export_settings, blender_object, target, property_name, property_definition, hubs_config):
+    # Convert RGB color array to hex. Blender stores colors in linear space and GLTF color factors are typically in linear space
+    c = getattr(target, property_name)
+    return "#{0:02x}{1:02x}{2:02x}".format(max(0, min(int(c[0] * 256.0), 255)), max(0, min(int(c[1] * 256.0), 255)), max(0, min(int(c[2] * 256.0), 255)))
+
+# MOZ_lightmap extension data
+def gather_lightmap_texture_info(blender_material, export_settings):
+    nodes = blender_material.node_tree.nodes
+    lightmap_node = next((n for n in nodes if isinstance(n, MozLightmapNode)), None)
+
+    if not lightmap_node: return
+
+    texture_socket = lightmap_node.inputs.get("Lightmap")
+    intensity = lightmap_node.intensity
+
+    # TODO this assumes a single image directly connected to the socket
+    blender_image = texture_socket.links[0].from_node.image
+    texture = gather_texture(blender_image, export_settings)
+    tex_transform, tex_coord = gltf2_blender_gather_texture_info.__gather_texture_transform_and_tex_coord(texture_socket, export_settings)
+    texture_info = TextureInfo(
+        extensions=gltf2_blender_gather_texture_info.__gather_extensions(tex_transform, export_settings),
+        extras=None,
+        index=texture,
+        tex_coord=tex_coord
+    )
+
+    if not texture_info: return
+
+    return {
+        "intensity": intensity,
+        'extensions': texture_info.extensions,
+        'extras': texture_info.extras,
+        "index": texture_info.index,
+        "texCoord": texture_info.tex_coord
+    }
+
+
+# gather_texture/image with HDR support via MOZ_texture_rgbe
+
+from io_scene_gltf2.io.com.gltf2_io_extensions import Extension
+from io_scene_gltf2.io.com.gltf2_io import Texture, Image
 from io_scene_gltf2.io.exp.gltf2_io_binary_data import BinaryData
 from io_scene_gltf2.io.exp.gltf2_io_image_data import ImageData
+from io_scene_gltf2.blender.exp.gltf2_blender_image import ExportImage
+from typing import Optional
+
 class HubsImageData(ImageData):
     @property
     def file_extension(self):
         if self._mime_type == "image/vnd.radiance":
             return ".hdr"
-        return super.file_extension(self)
+        return super().file_extension()
 
-# TODO DRY this up
+class HubsExportImage(ExportImage):
+    @staticmethod
+    def from_blender_image(image: bpy.types.Image):
+        export_image = HubsExportImage()
+        for chan in range(image.channels):
+            export_image.fill_image(image, dst_chan=chan, src_chan=chan)
+        return export_image
+
+    def encode(self, mime_type: Optional[str]) -> bytes:
+        if mime_type == "image/vnd.radiance":
+            return self.encode_from_image_hdr(self.blender_image())
+        return super().encode(mime_type)
+
+    # TODO this should allow conversion from other HDR formats (namely EXR),
+    # in memory images, and combining separate channels like SDR images
+    def encode_from_image_hdr(self, image: bpy.types.Image) -> bytes:
+        if image.file_format == "HDR" and image.source == 'FILE' and not image.is_dirty:
+            if image.packed_file is not None:
+                return image.packed_file.data
+            else:
+                src_path = bpy.path.abspath(image.filepath_raw)
+                if os.path.isfile(src_path):
+                    with open(src_path, 'rb') as f:
+                        return f.read()
+
+        raise Exception("HDR images must be saved as a .hdr file before exporting")
+
 @cached
 def gather_image(blender_image, export_settings):
     if not blender_image:
         return None
 
-    is_hdr = blender_image.file_format == "HDR"
+    name, _extension = os.path.splitext(os.path.basename(blender_image.filepath))
 
-    # TODO handle non HDR images
-    if is_hdr:
-        mime_type = "image/vnd.radiance"
-        data = __encode_from_image(blender_image)
-        name, _extension = os.path.splitext(os.path.basename(blender_image.filepath))
-
-        buffer_view = None
-        uri = None
-        if export_settings[gltf2_blender_export_keys.FORMAT] == 'GLTF_SEPARATE':
-            uri = HubsImageData(data=data, mime_type=mime_type, name=name)
+    if export_settings["gltf_image_format"] == "AUTO":
+        if blender_image.file_format == "HDR":
+            mime_type = "image/vnd.radiance"
         else:
-            buffer_view = BinaryData(data=data)
+            mime_type = "image/png"
+    else:
+        mime_type = "image/jpeg"
 
-        return  gltf2_io.Image(
-            buffer_view=buffer_view,
-            extensions=None,
-            extras=None,
-            mime_type=mime_type,
-            name=name,
-            uri=uri
-        )
+    data = HubsExportImage.from_blender_image(blender_image).encode(mime_type)
+
+    if export_settings[gltf2_blender_export_keys.FORMAT] == 'GLTF_SEPARATE':
+        uri = HubsImageData(data=data, mime_type=mime_type, name=name)
+        buffer_view = None
+    else:
+        uri = None
+        buffer_view = BinaryData(data=data)
+
+    return  Image(
+        buffer_view=buffer_view,
+        extensions=None,
+        extras=None,
+        mime_type=mime_type,
+        name=name,
+        uri=uri
+    )
+
+    # export_user_extensions('gather_image_hook', export_settings, image, blender_shader_sockets)
 
     return None
 
@@ -202,141 +287,10 @@ def gather_texture(blender_image, export_settings):
 
     # export_user_extensions('gather_texture_hook', export_settings, texture, blender_shader_sockets)
 
-    return gltf2_io.Texture(
+    return Texture(
         extensions=texture_extensions,
         extras=None,
         name=None,
-        sampler=0,
+        sampler=None,
         source=None if is_hdr else image
-    )
-
-def gather_texture_property(export_settings, blender_object, target, property_name, property_definition, hubs_config):
-    blender_image = getattr(target, property_name)
-
-    texture = gather_texture(blender_image, export_settings)
-
-    if not texture:
-        return None
-
-    return {
-        "__mhc_link_type": "texture",
-        "index": texture
-    }
-
-def gather_collections_property(export_settings, blender_object, target, property_name, property_definition, hubs_config):
-    filtered_collection_names = []
-
-    collection_prefix_regex = None
-
-    if 'collectionPrefix' in property_definition:
-        collection_prefix = property_definition['collectionPrefix']
-        collection_prefix_regex = re.compile(r'^' + collection_prefix)
-
-    for collection in blender_object.users_collection:
-        if collection_prefix_regex and collection_prefix_regex.match(collection.name):
-            new_name = collection_prefix_regex.sub("", collection.name)
-            filtered_collection_names.append(new_name)
-        elif not collection_prefix_regex:
-            filtered_collection_names.append(collection.name)
-
-    return filtered_collection_names
-
-def gather_color_property(export_settings, blender_object, target, property_name, property_definition, hubs_config):
-    # Convert RGB color array to hex. Blender stores colors in linear space and GLTF color factors are typically in linear space
-    c = getattr(target, property_name)
-    return "#{0:02x}{1:02x}{2:02x}".format(max(0, min(int(c[0] * 256.0), 255)), max(0, min(int(c[1] * 256.0), 255)), max(0, min(int(c[2] * 256.0), 255)))
-
-# @cached
-def gather_lightmap_texture_info(blender_material, export_settings):
-    nodes = blender_material.node_tree.nodes
-    lightmap_node = next((n for n in nodes if isinstance(n, MozLightmapNode)), None)
-
-    if not lightmap_node: return
-
-    texture_socket = lightmap_node.inputs.get("Lightmap")
-    intensity = lightmap_node.intensity
-
-    print("gather_lightmap")
-
-    texture_info = gather_hdr_texture_info(texture_socket, (texture_socket,), export_settings)
-    if not texture_info: return
-
-    return {
-        "intensity": intensity,
-        'extensions': texture_info.extensions,
-        'extras': texture_info.extras,
-        "index": texture_info.index,
-        "texCoord": texture_info.tex_coord
-    }
-
-
-from io_scene_gltf2.blender.exp import gltf2_blender_gather_texture_info, gltf2_blender_gather_texture, gltf2_blender_export_keys
-from io_scene_gltf2.io.com.gltf2_io_extensions import Extension
-from io_scene_gltf2.io.com import gltf2_io
-
-# TODO this should allow conversion from other HDR formats (namely EXR), and in memory images
-def __encode_from_image(image: bpy.types.Image) -> bytes:
-    if image.source == 'FILE' and image.file_format == "HDR" and not image.is_dirty:
-        if image.packed_file is not None:
-            return image.packed_file.data
-        else:
-            src_path = bpy.path.abspath(image.filepath_raw)
-            if os.path.isfile(src_path):
-                with open(src_path, 'rb') as f:
-                    return f.read()
-
-    raise Exception("You must save your lightmap as a .hdr image.")
-
-def gather_hdr_texture_info(primary_socket, blender_shader_sockets, export_settings):
-    # TODO this assumes a single image directly connected to the socket
-    blender_image = primary_socket.links[0].from_node.image
-    is_hdr = blender_image.file_format == "HDR"
-    texture_extensions = {}
-
-    if is_hdr:
-        mime_type = "image/vnd.radiance"
-        data = __encode_from_image(blender_image)
-        name, _extension = os.path.splitext(os.path.basename(blender_image.filepath))
-
-        buffer_view = None
-        uri = None
-        if export_settings[gltf2_blender_export_keys.FORMAT] == 'GLTF_SEPARATE':
-            uri = HubsImageData(data=data, mime_type=mime_type, name=name)
-        else:
-            buffer_view = BinaryData(data=data)
-
-        image = gltf2_io.Image(
-            buffer_view=buffer_view,
-            extensions=None,
-            extras=None,
-            mime_type=mime_type,
-            name=name,
-            uri=uri
-        )
-
-        ext_name = "MOZ_texture_rgbe"
-        texture_extensions[ext_name] = Extension(
-            name=ext_name,
-            extension={
-                "source": image
-            },
-            required=False
-        )
-
-    texture = gltf2_io.Texture(
-        extensions=texture_extensions,
-        extras=None,
-        name=None,
-        sampler=gltf2_blender_gather_texture.__gather_sampler(blender_shader_sockets, export_settings),
-        source=None if is_hdr else gltf2_blender_gather_texture.__gather_source(blender_shader_sockets, export_settings)
-    )
-
-    # export_user_extensions('gather_texture_hook', export_settings, texture, blender_shader_sockets)
-
-    tex_transform, tex_coord = gltf2_blender_gather_texture_info.__gather_texture_transform_and_tex_coord(primary_socket, export_settings)
-    return gltf2_io.TextureInfo(
-        extensions=gltf2_blender_gather_texture_info.__gather_extensions(tex_transform, export_settings),
-        extras=None,
-        index=texture,
-        tex_coord=tex_coord
     )

--- a/gather_properties.py
+++ b/gather_properties.py
@@ -184,6 +184,9 @@ def gather_image(blender_image, export_settings):
 def gather_texture(blender_image, export_settings):
     image = gather_image(blender_image, export_settings)
 
+    if not image:
+        return None
+
     texture_extensions = {}
     is_hdr = blender_image and blender_image.file_format == "HDR"
 
@@ -209,9 +212,15 @@ def gather_texture(blender_image, export_settings):
 
 def gather_texture_property(export_settings, blender_object, target, property_name, property_definition, hubs_config):
     blender_image = getattr(target, property_name)
+
+    texture = gather_texture(blender_image, export_settings)
+
+    if not texture:
+        return None
+
     return {
         "__mhc_link_type": "texture",
-        "index": gather_texture(blender_image, export_settings)
+        "index": texture
     }
 
 def gather_collections_property(export_settings, blender_object, target, property_name, property_definition, hubs_config):


### PR DESCRIPTION
Adds the ability to export lightmap as RGBE .hdr lightmaps. Currently only works with images already in .hdr format (not .exr) but this should be easy to fix down the road. Note that HDR images *must be saved before exporting* or things will silently fail to export. There is currently not a great way to handle errors like that (see https://github.com/KhronosGroup/glTF-Blender-IO/issues/1411)

This is built against the current GLTF exporter but things may change depending on discussions upstream https://github.com/KhronosGroup/glTF-Blender-IO/pull/1410