### PR TITLE
Add "shadow" component

### DIFF
--- a/default-config.json
+++ b/default-config.json
@@ -882,6 +882,14 @@
         }
       },
       "deps": ["audio-params"]
+    },
+    "shadow": {
+      "category": "Elements",
+      "node": true,
+      "properties": {
+        "cast": { "type": "bool", "default": true },
+        "receive": { "type": "bool", "default": true }
+      }
     }
   }
 }


### PR DESCRIPTION
The "shadow" component isn't available for Blender projects, which limits complex scene lighting.