### PR TITLE
Added missing spot-light component

### DIFF
--- a/components.py
+++ b/components.py
@@ -121,7 +121,9 @@ def define_property(class_name, property_name, property_definition, hubs_context
             name=display_name,
             description=property_definition.get("description") or "",
             subtype=property_definition.get("subType") or "NONE",
-            unit=property_definition.get("unit") or "NONE"
+            unit=property_definition.get("unit") or "NONE",
+            min=property_definition.get("min") if "min" in property_definition else -1e+38,
+            max=property_definition.get("max") if "max" in property_definition else +1e+38,
         )
     elif property_type == 'bool':
         return BoolProperty(

--- a/default-config.json
+++ b/default-config.json
@@ -141,6 +141,22 @@
         "shadowRadius": {"type": "float", "default": 1.0}
       }
     },
+    "spot-light": {
+      "category": "Elements",
+      "node": true,
+      "properties": {
+        "color": {"type": "color"},
+        "intensity": {"type": "float", "default": 1.0},
+        "range": {"type": "float", "default": 0.0},
+        "decay": {"type": "float", "default": 2.0},
+        "innerConeAngle": {"type": "float", "default": 0.0, "min": 0.0, "max": 1.57079632679, "subType":"ANGLE", "unit":"ROTATION"},
+        "outerConeAngle": {"type": "float", "default": 0.78539816339, "min": 0.0005729577951408, "max": 1.57079632679, "subType":"ANGLE", "unit":"ROTATION"},
+        "castShadow": { "type": "bool", "default": false },
+        "shadowMapResolution": {"type": "ivec2", "unit":"PIXEL", "default": [512, 512]},
+        "shadowBias": {"type": "float", "default": 0.0},
+        "shadowRadius": {"type": "float", "default": 1.0}
+      }
+    },
     "ambient-light": {
       "category": "Elements",
       "node": true,


### PR DESCRIPTION
This spot-light component completes the set of supported light types. I included a min-max range to match the Spoke defaults.

The min-max implementation takes the default values (+/- 3.402823e38) from [the Blender documentation](https://docs.blender.org/api/current/bpy.props.html#bpy.props.FloatProperty) and approximates them as +/- 1e38 to avoid any number parsing issues. If I was better at Python I could probably express this more elegantly.

Related: the "Elements" group is growing pretty big and we might want to consider putting the lights into a group of their own along with **shadow** and possibly **visible**.