### PR TITLE
Utility for lightmap preparation

### DIFF
--- a/addons/io_hubs_addon/components/operators.py
+++ b/addons/io_hubs_addon/components/operators.py
@@ -625,6 +625,7 @@ class OpenImage(Operator):
         context.window_manager.fileselect_add(self)
         return {'RUNNING_MODAL'}
 
+
 class PrepareHubsLightmaps(Operator):
     bl_idname = "wm.prepare_hubs_lightmaps"
     bl_label = "Select all lightmap elements for baking"
@@ -633,7 +634,7 @@ class PrepareHubsLightmaps(Operator):
     target: StringProperty(name="target")
 
     def execute(self, context):
-        try: 
+        try:
             lightmaps.selectLightmapComponents(self.target)
             lightmaps.assertSelectedObjectsAreSafeToBake(False)
             self.report({'INFO'}, "Lightmaps prepared and ready to bake")
@@ -648,12 +649,13 @@ class AddDecoyImageTextures(Operator):
     bl_description = "Adds decoy image textures to the materials of selected meshes if they are required"
 
     def execute(self, context):
-        try: 
+        try:
             decoyCount = lightmaps.assertSelectedObjectsAreSafeToBake(True)
             self.report({'INFO'}, f"Added {decoyCount} decoy textures")
         except Exception as e:
             self.report({'ERROR'}, str(e))
         return {'FINISHED'}
+
 
 class RemoveDecoyImageTextures(Operator):
     bl_idname = "wm.remove_decoy_image_textures"
@@ -661,7 +663,7 @@ class RemoveDecoyImageTextures(Operator):
     bl_description = "Remove all decoy image textures from materials regardless of selection"
 
     def execute(self, context):
-        try: 
+        try:
             decoyCount = lightmaps.removeAllDecoyImageTextures()
             self.report({'INFO'}, f"Removed {decoyCount} decoy textures")
         except Exception as e:

--- a/addons/io_hubs_addon/components/ui.py
+++ b/addons/io_hubs_addon/components/ui.py
@@ -180,6 +180,7 @@ class HubsBonePanel(bpy.types.Panel):
     def draw(self, context):
         draw_components_list(self, context)
 
+
 class HubsRenderPanel(bpy.types.Panel):
     bl_label = 'Hubs'
     bl_idname = "RENDER_PT_hubs"
@@ -190,7 +191,7 @@ class HubsRenderPanel(bpy.types.Panel):
     def draw(self, context):
         layout = self.layout
         row = layout.row()
-        lightmapImages = sorted(lightmaps.listLightmapImages(), key=lambda it:it.name)
+        lightmapImages = sorted(lightmaps.listLightmapImages(), key=lambda it: it.name)
         # Only show the panel if there are any lightmaps to prepare
         if len(lightmapImages) > 0:
             row.operator(operators.PrepareHubsLightmaps.bl_idname).target = ""
@@ -203,6 +204,7 @@ class HubsRenderPanel(bpy.types.Panel):
         row.label(text="Decoy Textures")
         row.operator(operators.AddDecoyImageTextures.bl_idname)
         row.operator(operators.RemoveDecoyImageTextures.bl_idname)
+
 
 class TooltipLabel(bpy.types.Operator):
     bl_idname = "ui.hubs_tooltip_label"


### PR DESCRIPTION
Lightmaps are a pain to bake because you have to remember to always do the following:

1. Select all the objects that should be light mapped
2. Make sure the selected UV layer is correct for every mesh
3. Make sure the lightmap image texture is active in the material graph

Miss any one of these steps and your bake will fail, probably silently and after a long time.

This PR adds a new Hubs 'Panel' to the Render Properties that has a button that finds all the _MOZ_lightmap_ components and traverses the scene graph making sure everything is selected and active. It also does some strict error checking, so a positive result means you are ready to bake, but anything inconsistent (such as a missing image or missing UV layer) will throw an error.

I've tried to match the same style as the other Hubs panels, but the actual scene logic was a bit verbose so I put it into it's own file.

Blender doesn't seem to have a concept of "parents" for things like meshes, which doesn't make much sense to me, but we just use full search in those instances. Performance isn't an issue, but it does make the code a bit ugly.