### PR TITLE
Add hemisphere light component

### DIFF
--- a/default-config.json
+++ b/default-config.json
@@ -157,6 +157,15 @@
         "intensity": {"type": "float", "default": 1.0}
       }
     },
+    "hemisphere-light": {
+      "category": "Elements",
+      "node": true,
+      "properties": {
+        "skyColor": {"type": "color"},
+        "groundColor": {"type": "color"},
+        "intensity": {"type": "float", "default": 1.0}
+      }
+    },
     "particle-emitter": {
       "node": true,
       "category": "Elements",


### PR DESCRIPTION
Hemisphere light is very useful, but was missing from the Hubs Blender Exporter.
This commit adds the component to Blender plugin.

Tested and working as expected when uploading glb as scene in Spoke.