### PR TITLE
Add bone migration.

### DIFF
--- a/addons/io_hubs_addon/components/definitions/audio_params.py
+++ b/addons/io_hubs_addon/components/definitions/audio_params.py
@@ -110,9 +110,16 @@ class AudioParams(HubsComponent):
     @classmethod
     def migrate(cls, version):
         if version < (1, 0, 0):
-            for ob in bpy.data.objects:
+            def migrate_data(ob):
                 if cls.get_name() in ob.hubs_component_list.items:
                     ob.hubs_component_audio_params.coneInnerAngle = radians(
                         ob.hubs_component_audio_params.coneInnerAngle)
                     ob.hubs_component_audio_params.coneOuterAngle = radians(
                         ob.hubs_component_audio_params.coneOuterAngle)
+
+            for ob in bpy.data.objects:
+                migrate_data(ob)
+
+                if ob.type == 'ARMATURE':
+                    for bone in ob.data.bones:
+                        migrate_data(bone)

--- a/addons/io_hubs_addon/components/definitions/loop_animation.py
+++ b/addons/io_hubs_addon/components/definitions/loop_animation.py
@@ -184,10 +184,17 @@ class LoopAnimation(HubsComponent):
     @classmethod
     def migrate(cls, version):
         if version < (1, 0, 0):
-            for ob in bpy.data.objects:
+            def migrate_data(ob):
                 if cls.get_name() in ob.hubs_component_list.items:
                     tracks = ob.hubs_component_loop_animation.clip.split(",")
                     for track_name in tracks:
                         if not has_track(ob.hubs_component_loop_animation.tracks_list, track_name):
                             track = ob.hubs_component_loop_animation.tracks_list.add()
                             track.name = track_name.strip()
+
+            for ob in bpy.data.objects:
+                migrate_data(ob)
+
+                if ob.type == 'ARMATURE':
+                    for bone in ob.data.bones:
+                        migrate_data(bone)

--- a/addons/io_hubs_addon/components/definitions/media_frame.py
+++ b/addons/io_hubs_addon/components/definitions/media_frame.py
@@ -122,11 +122,18 @@ class MediaFrame(HubsComponent):
         migrate_networked(cls.get_name())
 
         if version < (1, 0, 0):
-            for ob in bpy.data.objects:
+            def migrate_data(ob):
                 if cls.get_name() in ob.hubs_component_list.items:
                     bounds = ob.hubs_component_media_frame.bounds.copy()
                     bounds = Vector((bounds.x, bounds.z, bounds.y))
                     ob.hubs_component_media_frame.bounds = bounds
+
+            for ob in bpy.data.objects:
+                migrate_data(ob)
+
+                if ob.type == 'ARMATURE':
+                    for bone in ob.data.bones:
+                        migrate_data(bone)
 
     @staticmethod
     def register():

--- a/addons/io_hubs_addon/components/definitions/networked.py
+++ b/addons/io_hubs_addon/components/definitions/networked.py
@@ -26,7 +26,14 @@ class Networked(HubsComponent):
 
 
 def migrate_networked(component_name):
-    for ob in bpy.data.objects:
+    def migrate_data(ob):
         if component_name in ob.hubs_component_list.items:
             if Networked.get_name() not in ob.hubs_component_list.items:
                 add_component(ob, Networked.get_name())
+
+    for ob in bpy.data.objects:
+        migrate_data(ob)
+
+        if ob.type == 'ARMATURE':
+            for bone in ob.data.bones:
+                migrate_data(bone)

--- a/addons/io_hubs_addon/components/definitions/spawner.py
+++ b/addons/io_hubs_addon/components/definitions/spawner.py
@@ -31,7 +31,14 @@ class Spawner(HubsComponent):
     @classmethod
     def migrate(cls, version):
         if version < (1, 0, 0):
-            for ob in bpy.data.objects:
+            def migrate_data(ob):
                 if cls.get_name() in ob.hubs_component_list.items:
                     ob.hubs_component_spawner.applyGravity = ob.hubs_component_spawner[
                         'mediaOptions']['applyGravity']
+
+            for ob in bpy.data.objects:
+                migrate_data(ob)
+
+                if ob.type == 'ARMATURE':
+                    for bone in ob.data.bones:
+                        migrate_data(bone)


### PR DESCRIPTION
Add migration support for bones.  Note: with this migration, media frames that are on bones will draw their gizmos incorrectly (Y and Z will be inverted) in Blender, but it exports to Hubs correctly so it seems to be the gizmo drawing code that isn't accounting for bones properly.