### PR TITLE
Fix gizmos transforms for components in bones

### DIFF
--- a/addons/io_hubs_addon/components/definitions/audio_zone.py
+++ b/addons/io_hubs_addon/components/definitions/audio_zone.py
@@ -30,18 +30,20 @@ class AudioZone(HubsComponent):
     def update_gizmo(cls, ob, bone, target, gizmo):
         if bone:
             _, _, wScale = ob.matrix_world.decompose()
+            loc, rot, _ = bone.matrix.to_4x4().decompose()
             scaleMat = Matrix.Diagonal(bone.bbone_scaleout).to_4x4(
             ) @ Matrix.Diagonal(wScale).to_4x4()
-            mat = ob.matrix_world @ bone.matrix.to_4x4()
-            _, rot, _ = mat.decompose()
-            loc = bone.tail
+            mat_offset = Matrix.Translation(bone.tail - bone.head)
+            mat = ob.matrix_world @ mat_offset @ Matrix.Translation(
+                loc) @ rot.normalized().to_matrix().to_4x4() @ scaleMat
         else:
             loc, rot, scale = ob.matrix_world.decompose()
             scaleMat = Matrix.Diagonal(scale).to_4x4()
+            mat = Matrix.Translation(
+                loc) @ rot.normalized().to_matrix().to_4x4() @ scaleMat
 
         gizmo.hide = not ob.visible_get()
-        gizmo.matrix_basis = Matrix.Translation(
-            loc) @ rot.normalized().to_matrix().to_4x4() @ scaleMat
+        gizmo.matrix_basis = mat
 
     @classmethod
     def create_gizmo(cls, ob, gizmo_group):

--- a/addons/io_hubs_addon/components/definitions/audio_zone.py
+++ b/addons/io_hubs_addon/components/definitions/audio_zone.py
@@ -1,9 +1,8 @@
 from bpy.props import BoolProperty
-from ..gizmos import CustomModelGizmo
+from ..gizmos import CustomModelGizmo, bone_matrix_world
 from ..models import box
 from ..hubs_component import HubsComponent
 from ..types import Category, PanelType, NodeType
-from mathutils import Matrix
 from .networked import migrate_networked
 
 
@@ -29,18 +28,9 @@ class AudioZone(HubsComponent):
     @classmethod
     def update_gizmo(cls, ob, bone, target, gizmo):
         if bone:
-            _, _, wScale = ob.matrix_world.decompose()
-            loc, rot, _ = bone.matrix.to_4x4().decompose()
-            scaleMat = Matrix.Diagonal(bone.bbone_scaleout).to_4x4(
-            ) @ Matrix.Diagonal(wScale).to_4x4()
-            mat_offset = Matrix.Translation(bone.tail - bone.head)
-            mat = ob.matrix_world @ mat_offset @ Matrix.Translation(
-                loc) @ rot.normalized().to_matrix().to_4x4() @ scaleMat
+            mat = bone_matrix_world(ob, bone)
         else:
-            loc, rot, scale = ob.matrix_world.decompose()
-            scaleMat = Matrix.Diagonal(scale).to_4x4()
-            mat = Matrix.Translation(
-                loc) @ rot.normalized().to_matrix().to_4x4() @ scaleMat
+            mat = ob.matrix_world.copy()
 
         gizmo.hide = not ob.visible_get()
         gizmo.matrix_basis = mat

--- a/addons/io_hubs_addon/components/definitions/media_frame.py
+++ b/addons/io_hubs_addon/components/definitions/media_frame.py
@@ -1,6 +1,7 @@
 import bpy
 from bpy.props import EnumProperty, FloatVectorProperty, BoolProperty
 from bpy.types import (Gizmo, Bone, EditBone)
+from ..gizmos import bone_matrix_world
 from ..models import box
 from ..hubs_component import HubsComponent
 from ..types import Category, PanelType, NodeType
@@ -88,10 +89,7 @@ class MediaFrame(HubsComponent):
 
         scale = gizmo.target_get_value("bounds")
         if bone:
-            loc, rot, _ = bone.matrix.to_4x4().decompose()
-            mat_offset = Matrix.Translation(bone.tail - bone.head)
-            mat = ob.matrix_world @ mat_offset @ Matrix.Translation(
-                loc) @ rot.normalized().to_matrix().to_4x4() @ Matrix.Diagonal(scale).to_4x4()
+            mat = bone_matrix_world(ob, bone, scale)
         else:
             loc, rot, _ = ob.matrix_world.decompose()
             mat = Matrix.Translation(

--- a/addons/io_hubs_addon/components/definitions/media_frame.py
+++ b/addons/io_hubs_addon/components/definitions/media_frame.py
@@ -86,17 +86,19 @@ class MediaFrame(HubsComponent):
         gizmo.target_set_prop(
             "bounds", target.hubs_component_media_frame, "bounds")
 
+        scale = gizmo.target_get_value("bounds")
         if bone:
-            mat = ob.matrix_world @ bone.matrix.to_4x4()
-            _, rot, _ = mat.decompose()
-            loc = bone.tail
+            loc, rot, _ = bone.matrix.to_4x4().decompose()
+            mat_offset = Matrix.Translation(bone.tail - bone.head)
+            mat = ob.matrix_world @ mat_offset @ Matrix.Translation(
+                loc) @ rot.normalized().to_matrix().to_4x4() @ Matrix.Diagonal(scale).to_4x4()
         else:
             loc, rot, _ = ob.matrix_world.decompose()
+            mat = Matrix.Translation(
+                loc) @ rot.normalized().to_matrix().to_4x4() @ Matrix.Diagonal(scale).to_4x4()
 
-        scale = gizmo.target_get_value("bounds")
-        mat_out = Matrix.Translation(
-            loc) @ rot.normalized().to_matrix().to_4x4() @ Matrix.Diagonal(scale).to_4x4()
-        gizmo.matrix_basis = mat_out
+        gizmo.hide = not ob.visible_get()
+        gizmo.matrix_basis = mat
 
     @classmethod
     def create_gizmo(cls, ob, gizmo_group):

--- a/addons/io_hubs_addon/components/definitions/waypoint.py
+++ b/addons/io_hubs_addon/components/definitions/waypoint.py
@@ -57,15 +57,13 @@ class Waypoint(HubsComponent):
     @classmethod
     def update_gizmo(cls, ob, bone, target, gizmo):
         if bone:
-            mat = ob.matrix_world @ bone.matrix.to_4x4()
-            _, rot, scale = mat.decompose()
-            loc = bone.tail
+            mat_offset = Matrix.Translation(bone.tail - bone.head)
+            mat = ob.matrix_world @ mat_offset @ bone.matrix.to_4x4()
         else:
-            loc, rot, scale = ob.matrix_world.decompose()
+            mat = ob.matrix_world.copy()
 
         gizmo.hide = not ob.visible_get()
-        gizmo.matrix_basis = Matrix.Translation(
-            loc) @ rot.normalized().to_matrix().to_4x4() @ Matrix.Diagonal(scale).to_4x4()
+        gizmo.matrix_basis = mat
 
     @classmethod
     def create_gizmo(cls, ob, gizmo_group):

--- a/addons/io_hubs_addon/components/definitions/waypoint.py
+++ b/addons/io_hubs_addon/components/definitions/waypoint.py
@@ -1,9 +1,8 @@
 from ..models import spawn_point
-from ..gizmos import CustomModelGizmo
+from ..gizmos import CustomModelGizmo, bone_matrix_world
 from ..types import Category, PanelType, NodeType
 from ..hubs_component import HubsComponent
 from bpy.props import BoolProperty
-from mathutils import Matrix
 from .networked import migrate_networked
 
 
@@ -57,8 +56,7 @@ class Waypoint(HubsComponent):
     @classmethod
     def update_gizmo(cls, ob, bone, target, gizmo):
         if bone:
-            mat_offset = Matrix.Translation(bone.tail - bone.head)
-            mat = ob.matrix_world @ mat_offset @ bone.matrix.to_4x4()
+            mat = bone_matrix_world(ob, bone)
         else:
             mat = ob.matrix_world.copy()
 

--- a/addons/io_hubs_addon/components/gizmos.py
+++ b/addons/io_hubs_addon/components/gizmos.py
@@ -1,12 +1,27 @@
 import bpy
 from bpy.types import (Gizmo, GizmoGroup)
-from bpy.props import BoolProperty
 from .components_registry import get_component_by_name
 from bpy.app.handlers import persistent
+from math import radians
+from mathutils import Matrix
 
 
 def gizmo_update(obj, gizmo):
     gizmo.matrix_basis = obj.matrix_world.normalized()
+
+
+def bone_matrix_world(ob, bone, scaleOverride=None):
+    loc, rot, scale = bone.matrix.to_4x4().decompose()
+    # Account for bones using Y up
+    rot_offset = Matrix.Rotation(radians(-90), 4, 'X').to_4x4()
+    if scaleOverride:
+        scale = scaleOverride
+    else:
+        scale = scale.xzy
+    final_loc = ob.matrix_world @ Matrix.Translation(loc)
+    final_rot = rot.normalized().to_matrix().to_4x4() @ rot_offset
+    final_scale = Matrix.Diagonal(scale).to_4x4()
+    return final_loc @ final_rot @ final_scale
 
 
 class CustomModelGizmo(Gizmo):


### PR DESCRIPTION
This PR fixes gizmo transform issues when a component is attached to a bone. 

Related: https://github.com/MozillaReality/hubs-blender-exporter/pull/68#issuecomment-1168532385