### PR TITLE
Hubs Add Component Menu Improvement Experiment

### DIFF
--- a/addons/io_hubs_addon/__init__.py
+++ b/addons/io_hubs_addon/__init__.py
@@ -1,5 +1,6 @@
 from .io import gltf_exporter
 from . import (nodes, components)
+from . import preferences
 bl_info = {
     "name": "Hubs Blender Addon",
     "author": "Mozilla Hubs",
@@ -16,6 +17,7 @@ bl_info = {
 
 
 def register():
+    preferences.register()
     gltf_exporter.register()
     nodes.register()
     components.register()
@@ -25,6 +27,7 @@ def unregister():
     components.unregister()
     nodes.unregister()
     gltf_exporter.unregister()
+    preferences.unregister()
 
 
 # called by gltf-blender-io after it has loaded

--- a/addons/io_hubs_addon/components/components_registry.py
+++ b/addons/io_hubs_addon/components/components_registry.py
@@ -32,7 +32,7 @@ def get_components_in_dir(dir):
         elif isdir(f_path) and f != "__pycache__":
             comps = [f + '.' + name for name in get_components_in_dir(f_path)]
             components = components + comps
-    return components
+    return sorted(components)
 
 
 def get_component_definitions():

--- a/addons/io_hubs_addon/components/definitions/ambient_light.py
+++ b/addons/io_hubs_addon/components/definitions/ambient_light.py
@@ -7,7 +7,7 @@ class AmbientLight(HubsComponent):
     _definition = {
         'name': 'ambient-light',
         'display_name': 'Ambient Light',
-        'category': Category.ELEMENTS,
+        'category': Category.LIGHTS,
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'LIGHT_HEMI'

--- a/addons/io_hubs_addon/components/definitions/ammo_shape.py
+++ b/addons/io_hubs_addon/components/definitions/ammo_shape.py
@@ -8,7 +8,7 @@ class AmmoShape(HubsComponent):
     _definition = {
         'name': 'ammo-shape',
         'display_name': 'Ammo Shape',
-        'category': Category.SCENE,
+        'category': Category.OBJECT,
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'SCENE_DATA'

--- a/addons/io_hubs_addon/components/definitions/audio.py
+++ b/addons/io_hubs_addon/components/definitions/audio.py
@@ -8,7 +8,7 @@ class Audio(HubsComponent):
     _definition = {
         'name': 'audio',
         'display_name': 'Audio',
-        'category': Category.AV,
+        'category': Category.MEDIA,
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'deps': ['networked', 'audio-params'],

--- a/addons/io_hubs_addon/components/definitions/audio.py
+++ b/addons/io_hubs_addon/components/definitions/audio.py
@@ -8,7 +8,7 @@ class Audio(HubsComponent):
     _definition = {
         'name': 'audio',
         'display_name': 'Audio',
-        'category': Category.ELEMENTS,
+        'category': Category.AV,
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'deps': ['networked', 'audio-params'],

--- a/addons/io_hubs_addon/components/definitions/audio_source.py
+++ b/addons/io_hubs_addon/components/definitions/audio_source.py
@@ -7,7 +7,7 @@ class AudioSource(HubsComponent):
     _definition = {
         'name': 'zone-audio-source',
         'display_name': 'Audio Source',
-        'category': Category.ELEMENTS,
+        'category': Category.AV,
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'MOD_WAVE'

--- a/addons/io_hubs_addon/components/definitions/audio_source.py
+++ b/addons/io_hubs_addon/components/definitions/audio_source.py
@@ -7,7 +7,7 @@ class AudioSource(HubsComponent):
     _definition = {
         'name': 'zone-audio-source',
         'display_name': 'Audio Source',
-        'category': Category.AV,
+        'category': Category.MEDIA,
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'MOD_WAVE'

--- a/addons/io_hubs_addon/components/definitions/audio_target.py
+++ b/addons/io_hubs_addon/components/definitions/audio_target.py
@@ -75,7 +75,7 @@ class AudioTarget(HubsComponent):
     _definition = {
         'name': 'audio-target',
         'display_name': 'Audio Target',
-        'category': Category.AV,
+        'category': Category.MEDIA,
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'deps': ['audio-params'],

--- a/addons/io_hubs_addon/components/definitions/audio_target.py
+++ b/addons/io_hubs_addon/components/definitions/audio_target.py
@@ -75,7 +75,7 @@ class AudioTarget(HubsComponent):
     _definition = {
         'name': 'audio-target',
         'display_name': 'Audio Target',
-        'category': Category.ELEMENTS,
+        'category': Category.AV,
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'deps': ['audio-params'],

--- a/addons/io_hubs_addon/components/definitions/audio_zone.py
+++ b/addons/io_hubs_addon/components/definitions/audio_zone.py
@@ -10,7 +10,7 @@ class AudioZone(HubsComponent):
     _definition = {
         'name': 'audio-zone',
         'display_name': 'Audio Zone',
-        'category': Category.AV,
+        'category': Category.MEDIA,
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'deps': ['networked', 'audio-params'],

--- a/addons/io_hubs_addon/components/definitions/audio_zone.py
+++ b/addons/io_hubs_addon/components/definitions/audio_zone.py
@@ -10,7 +10,7 @@ class AudioZone(HubsComponent):
     _definition = {
         'name': 'audio-zone',
         'display_name': 'Audio Zone',
-        'category': Category.ELEMENTS,
+        'category': Category.AV,
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'deps': ['networked', 'audio-params'],

--- a/addons/io_hubs_addon/components/definitions/billboard.py
+++ b/addons/io_hubs_addon/components/definitions/billboard.py
@@ -7,7 +7,7 @@ class Billboard(HubsComponent):
     _definition = {
         'name': 'billboard',
         'display_name': 'Billboard',
-        'category': Category.ELEMENTS,
+        'category': Category.OBJECT,
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'IMAGE_PLANE'

--- a/addons/io_hubs_addon/components/definitions/directional_light.py
+++ b/addons/io_hubs_addon/components/definitions/directional_light.py
@@ -7,7 +7,7 @@ class DirectionalLight(HubsComponent):
     _definition = {
         'name': 'directional-light',
         'display_name': 'Directional Light',
-        'category': Category.ELEMENTS,
+        'category': Category.LIGHTS,
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'LIGHT_SUN'

--- a/addons/io_hubs_addon/components/definitions/frustrum.py
+++ b/addons/io_hubs_addon/components/definitions/frustrum.py
@@ -7,7 +7,7 @@ class Frustrum(HubsComponent):
     _definition = {
         'name': 'frustrum',
         'display_name': 'Frustrum',
-        'category': Category.ELEMENTS,
+        'category': Category.OBJECT,
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT],
         'icon': 'IMAGE_PLANE'

--- a/addons/io_hubs_addon/components/definitions/hemisphere_light.py
+++ b/addons/io_hubs_addon/components/definitions/hemisphere_light.py
@@ -7,7 +7,7 @@ class HemisphereLight(HubsComponent):
     _definition = {
         'name': 'hemisphere-light',
         'display_name': 'Hemisphere Light',
-        'category': Category.ELEMENTS,
+        'category': Category.LIGHTS,
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'LIGHT_AREA'

--- a/addons/io_hubs_addon/components/definitions/image.py
+++ b/addons/io_hubs_addon/components/definitions/image.py
@@ -9,7 +9,7 @@ class Image(HubsComponent):
     _definition = {
         'name': 'image',
         'display_name': 'Image',
-        'category': Category.AV,
+        'category': Category.MEDIA,
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'FILE_IMAGE',

--- a/addons/io_hubs_addon/components/definitions/image.py
+++ b/addons/io_hubs_addon/components/definitions/image.py
@@ -9,7 +9,7 @@ class Image(HubsComponent):
     _definition = {
         'name': 'image',
         'display_name': 'Image',
-        'category': Category.ELEMENTS,
+        'category': Category.AV,
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'FILE_IMAGE',

--- a/addons/io_hubs_addon/components/definitions/model.py
+++ b/addons/io_hubs_addon/components/definitions/model.py
@@ -8,7 +8,7 @@ class Model(HubsComponent):
     _definition = {
         'name': 'model',
         'display_name': 'Model',
-        'category': Category.ELEMENTS,
+        'category': Category.MEDIA,
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'SCENE_DATA',

--- a/addons/io_hubs_addon/components/definitions/point_light.py
+++ b/addons/io_hubs_addon/components/definitions/point_light.py
@@ -7,7 +7,7 @@ class PointLight(HubsComponent):
     _definition = {
         'name': 'point-light',
         'display_name': 'Point Light',
-        'category': Category.ELEMENTS,
+        'category': Category.LIGHTS,
         'node_type': NodeType. NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'LIGHT_POINT'

--- a/addons/io_hubs_addon/components/definitions/shadow.py
+++ b/addons/io_hubs_addon/components/definitions/shadow.py
@@ -7,7 +7,7 @@ class Shadow(HubsComponent):
     _definition = {
         'name': 'shadow',
         'display_name': 'Shadow',
-        'category': Category.ELEMENTS,
+        'category': Category.OBJECT,
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT],
         'icon': 'MOD_MASK'

--- a/addons/io_hubs_addon/components/definitions/spot_light.py
+++ b/addons/io_hubs_addon/components/definitions/spot_light.py
@@ -8,7 +8,7 @@ class SpotLight(HubsComponent):
     _definition = {
         'name': 'spot-light',
         'display_name': 'Spot Light',
-        'category': Category.ELEMENTS,
+        'category': Category.LIGHTS,
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'LIGHT_SPOT'

--- a/addons/io_hubs_addon/components/definitions/video.py
+++ b/addons/io_hubs_addon/components/definitions/video.py
@@ -9,7 +9,7 @@ class Video(HubsComponent):
     _definition = {
         'name': 'video',
         'display_name': 'Video',
-        'category': Category.AV,
+        'category': Category.MEDIA,
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'deps': ['networked', 'audio-params'],

--- a/addons/io_hubs_addon/components/definitions/video.py
+++ b/addons/io_hubs_addon/components/definitions/video.py
@@ -9,7 +9,7 @@ class Video(HubsComponent):
     _definition = {
         'name': 'video',
         'display_name': 'Video',
-        'category': Category.ELEMENTS,
+        'category': Category.AV,
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'deps': ['networked', 'audio-params'],

--- a/addons/io_hubs_addon/components/definitions/video_texture_source.py
+++ b/addons/io_hubs_addon/components/definitions/video_texture_source.py
@@ -8,7 +8,7 @@ class VideoTextureSource(HubsComponent):
     _definition = {
         'name': 'video-texture-source',
         'display_name': 'Video Texture Source',
-        'category': Category.SCENE,
+        'category': Category.AV,
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'VIEW_CAMERA'

--- a/addons/io_hubs_addon/components/definitions/video_texture_source.py
+++ b/addons/io_hubs_addon/components/definitions/video_texture_source.py
@@ -8,7 +8,7 @@ class VideoTextureSource(HubsComponent):
     _definition = {
         'name': 'video-texture-source',
         'display_name': 'Video Texture Source',
-        'category': Category.AV,
+        'category': Category.MEDIA,
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'VIEW_CAMERA'

--- a/addons/io_hubs_addon/components/definitions/video_texture_target.py
+++ b/addons/io_hubs_addon/components/definitions/video_texture_target.py
@@ -74,7 +74,7 @@ class VideoTextureTarget(HubsComponent):
     _definition = {
         'name': 'video-texture-target',
         'display_name': 'Video Texture Target',
-        'category': Category.AVATAR,
+        'category': Category.AV,
         'node_type': NodeType.MATERIAL,
         'panel_type': [PanelType.MATERIAL],
         'icon': 'IMAGE_DATA'

--- a/addons/io_hubs_addon/components/definitions/video_texture_target.py
+++ b/addons/io_hubs_addon/components/definitions/video_texture_target.py
@@ -74,7 +74,7 @@ class VideoTextureTarget(HubsComponent):
     _definition = {
         'name': 'video-texture-target',
         'display_name': 'Video Texture Target',
-        'category': Category.AV,
+        'category': Category.MEDIA,
         'node_type': NodeType.MATERIAL,
         'panel_type': [PanelType.MATERIAL],
         'icon': 'IMAGE_DATA'

--- a/addons/io_hubs_addon/components/definitions/waypoint.py
+++ b/addons/io_hubs_addon/components/definitions/waypoint.py
@@ -10,7 +10,7 @@ class Waypoint(HubsComponent):
     _definition = {
         'name': 'waypoint',
         'display_name': 'Waypoint',
-        'category': Category.OBJECT,
+        'category': Category.ELEMENTS,
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'gizmo': 'waypoint',

--- a/addons/io_hubs_addon/components/types.py
+++ b/addons/io_hubs_addon/components/types.py
@@ -22,3 +22,5 @@ class Category(Enum):
     ANIMATION = 'Animation'
     AVATAR = 'Avatar'
     MISC = 'Misc'
+    LIGHTS = 'Lights'
+    AV = 'A/V Elements'

--- a/addons/io_hubs_addon/components/types.py
+++ b/addons/io_hubs_addon/components/types.py
@@ -23,4 +23,4 @@ class Category(Enum):
     AVATAR = 'Avatar'
     MISC = 'Misc'
     LIGHTS = 'Lights'
-    AV = 'A/V Elements'
+    MEDIA = 'Media'

--- a/addons/io_hubs_addon/preferences.py
+++ b/addons/io_hubs_addon/preferences.py
@@ -1,0 +1,26 @@
+import bpy
+from bpy.types import AddonPreferences
+from bpy.props import IntProperty
+
+class HubsPreferences(AddonPreferences):
+    bl_idname = __package__
+
+    row_length: IntProperty(
+        name="Add Component Menu Row Length",
+        description="Allows you to control how many categories are added to a row before it starts on the next row. Set to 0 to have it all on one row",
+        default=4,
+        min=0,
+        )
+
+    def draw(self, context):
+        layout = self.layout
+        box = layout.box()
+
+        box.row().prop(self, "row_length")
+
+
+def register():
+    bpy.utils.register_class(HubsPreferences)
+
+def unregister():
+    bpy.utils.unregister_class(HubsPreferences)


### PR DESCRIPTION
Sort categories and components alphabetically, and allow for multiple rows in the menu,
which is user configurable via a row length property in the add-on's new preferences.

Also, separated out some of the components in the Elements category into
their own categories: A/V Elements, and Lights.

Note: the logic seems to be pretty solid, but it can be a bit confusing.  Splitting the sorting and organizing code off into its own function (or multiple functions) may be desirable.
![2022-07-12_22-06](https://user-images.githubusercontent.com/9795121/178638848-d8dcc3c7-0f7b-4c18-8452-955d2c43e6d5.png)

