### PR TITLE
Move reflection probe resolution and baking to a global scene prop

### DIFF
--- a/addons/io_hubs_addon/components/definitions/reflection_probe.py
+++ b/addons/io_hubs_addon/components/definitions/reflection_probe.py
@@ -301,10 +301,7 @@ class ReflectionProbe(HubsComponent):
         row = layout.row()
         row.label(text="You can bake all reflection probes at once from the scene settings.",
                   icon='INFO')
-        layout.separator()
         super().draw(context, layout, panel_type)
-
-        layout.separator()
 
         bake_msg = "Baking..." if probe_baking else "Bake"
         bake_op = layout.operator(
@@ -312,6 +309,12 @@ class ReflectionProbe(HubsComponent):
             text=bake_msg
         )
         bake_op.bake_selected = True
+
+        if not hasattr(bpy.context.scene, "cycles"):
+            row = layout.row()
+            row.alert = True
+            row.label(text="Baking requires Cycles addon to be enabled.",
+                      icon='ERROR')
 
     def gather(self, export_settings, object):
         return {
@@ -340,18 +343,18 @@ class ReflectionProbe(HubsComponent):
                 row.label(text="Reflection probe resolution has changed. Bake again to apply the new resolution.",
                           icon='ERROR')
 
+            bake_msg = "Baking..." if probe_baking else "Bake All"
+            bake_op = col.operator(
+                "render.hubs_render_reflection_probe",
+                text=bake_msg
+            )
+            bake_op.bake_selected = False
+
             if not hasattr(bpy.context.scene, "cycles"):
                 row = col.row()
                 row.alert = True
                 row.label(text="Baking requires Cycles addon to be enabled.",
                           icon='ERROR')
-
-            bake_msg = "Baking..." if probe_baking else "Bake All"
-            bake_op = layout.operator(
-                "render.hubs_render_reflection_probe",
-                text=bake_msg
-            )
-            bake_op.bake_selected = False
 
     @classmethod
     def poll(cls, context, panel_type):

--- a/addons/io_hubs_addon/components/definitions/reflection_probe.py
+++ b/addons/io_hubs_addon/components/definitions/reflection_probe.py
@@ -33,6 +33,7 @@ RESOLUTION_ITEMS = [
 ]
 
 probe_baking = False
+show_warning = False
 
 
 def get_probes():
@@ -242,6 +243,10 @@ class ReflectionProbe(HubsComponent):
     )
 
     def draw(self, context, layout, panel_type):
+        if show_warning:
+            row = layout.row()
+            row.label(text="Reflection probes resolution is now set globally in scene settings.",
+                      icon='INFO')
         super().draw(context, layout, panel_type)
 
     def gather(self, export_settings, object):
@@ -281,6 +286,12 @@ class ReflectionProbe(HubsComponent):
     @classmethod
     def poll(cls, context, panel_type):
         return context.object.type == 'LIGHT_PROBE'
+
+    @classmethod
+    def migrate(cls, version):
+        if version < (1, 0, 0):
+            global show_warning
+            show_warning = True
 
     @staticmethod
     def register():

--- a/addons/io_hubs_addon/components/definitions/reflection_probe.py
+++ b/addons/io_hubs_addon/components/definitions/reflection_probe.py
@@ -112,7 +112,7 @@ class BakeProbeOperator(bpy.types.Operator):
 
     @ classmethod
     def poll(cls, context):
-        return not probe_baking
+        return not probe_baking and hasattr(bpy.context.scene, "cycles")
 
     def render_post(self, scene, depsgraph):
         print("Finished render")
@@ -322,6 +322,12 @@ class ReflectionProbe(HubsComponent):
                 row = col.row()
                 row.alert = True
                 row.label(text="Reflection probe resolution has changed. Bake again to apply the new resolution.",
+                          icon='ERROR')
+
+            if not hasattr(bpy.context.scene, "cycles"):
+                row = col.row()
+                row.alert = True
+                row.label(text="Baking requires Cycles addon to be enabled.",
                           icon='ERROR')
 
             bake_msg = "Baking..." if probe_baking else "Bake All"

--- a/addons/io_hubs_addon/components/definitions/reflection_probe.py
+++ b/addons/io_hubs_addon/components/definitions/reflection_probe.py
@@ -4,7 +4,7 @@ from bpy.types import Image, PropertyGroup
 
 from ...components.utils import is_gpu_available
 
-from ...preferences import HubsPreference, get_addon_pref
+from ...preferences import get_addon_pref
 
 from ..components_registry import get_components_registry
 from ..hubs_component import HubsComponent
@@ -195,8 +195,8 @@ class BakeProbeOperator(bpy.types.Operator):
                 for probe in self.probes:
                     image_name = "generated_cubemap-%s" % probe.name
                     img = bpy.data.images.get(image_name)
-                    img_path = "%s/%s.hdr" % (get_addon_pref(
-                        HubsPreference.TMP_PATH), probe.name)
+                    img_path = "%s/%s.hdr" % (get_addon_pref(context).tmp_path,
+                                              probe.name)
                     if not img:
                         img = bpy.data.images.load(filepath=img_path)
                         img.name = image_name
@@ -270,7 +270,7 @@ class BakeProbeOperator(bpy.types.Operator):
         bpy.context.scene.render.resolution_y = y
         bpy.context.scene.render.image_settings.file_format = "HDR"
         bpy.context.scene.render.filepath = "%s/%s.hdr" % (
-            get_addon_pref(HubsPreference.TMP_PATH), probe.name)
+            get_addon_pref(context).tmp_path, probe.name)
 
         # TODO don't clobber renderer properties
         # TODO handle skipping compositor

--- a/addons/io_hubs_addon/components/definitions/reflection_probe.py
+++ b/addons/io_hubs_addon/components/definitions/reflection_probe.py
@@ -35,7 +35,6 @@ RESOLUTION_ITEMS = [
 ]
 
 probe_baking = False
-show_warning = False
 
 
 def get_resolutions(self, context):
@@ -299,10 +298,10 @@ class ReflectionProbe(HubsComponent):
     )
 
     def draw(self, context, layout, panel_type):
-        if show_warning:
-            row = layout.row()
-            row.label(text="You can bake all reflection probes at once from the scene settings.",
-                      icon='INFO')
+        row = layout.row()
+        row.label(text="You can bake all reflection probes at once from the scene settings.",
+                  icon='INFO')
+        layout.separator()
         super().draw(context, layout, panel_type)
 
         layout.separator()
@@ -357,12 +356,6 @@ class ReflectionProbe(HubsComponent):
     @classmethod
     def poll(cls, context, panel_type):
         return context.object.type == 'LIGHT_PROBE'
-
-    @classmethod
-    def migrate(cls, version):
-        if version < (1, 0, 0):
-            global show_warning
-            show_warning = True
 
     @staticmethod
     def register():

--- a/addons/io_hubs_addon/components/definitions/reflection_probe.py
+++ b/addons/io_hubs_addon/components/definitions/reflection_probe.py
@@ -2,6 +2,8 @@ import bpy
 from bpy.props import PointerProperty, EnumProperty, StringProperty
 from bpy.types import Image, PropertyGroup
 
+from ...components.utils import is_gpu_available
+
 from ...preferences import Preference, get_addon_pref
 
 from ..components_registry import get_components_registry
@@ -112,6 +114,7 @@ class BakeProbeOperator(bpy.types.Operator):
 
         self.prev_render_camera = bpy.context.scene.camera
         self.prev_render_engine = bpy.context.scene.render.engine
+        self.prev_cycles_device = bpy.context.scene.cycles.device
         self.prev_render_rex_x = bpy.context.scene.render.resolution_x
         self.prev_render_res_y = bpy.context.scene.render.resolution_y
         self.prev_render_file_format = bpy.context.scene.render.image_settings.file_format
@@ -194,6 +197,7 @@ class BakeProbeOperator(bpy.types.Operator):
     def restore_render_props(self):
         bpy.context.scene.camera = self.prev_render_camera
         bpy.context.scene.render.engine = self.prev_render_engine
+        bpy.context.scene.cycles.device = self.prev_cycles_device
         bpy.context.scene.render.resolution_x = self.prev_render_rex_x
         bpy.context.scene.render.resolution_y = self.prev_render_res_y
         bpy.context.scene.render.image_settings.file_format = self.prev_render_file_format
@@ -219,6 +223,8 @@ class BakeProbeOperator(bpy.types.Operator):
         bpy.context.scene.render.engine = "CYCLES"
         (x, y) = RESOLUTIONS[context.scene.hubs_scene_reflection_probe_properties.get(
             'resolution', 1)]
+        bpy.context.scene.cycles.device = "GPU" if is_gpu_available(
+            context) else "CPU"
         bpy.context.scene.render.resolution_x = x
         bpy.context.scene.render.resolution_y = y
         bpy.context.scene.render.image_settings.file_format = "HDR"

--- a/addons/io_hubs_addon/components/definitions/reflection_probe.py
+++ b/addons/io_hubs_addon/components/definitions/reflection_probe.py
@@ -4,7 +4,7 @@ from bpy.types import Image, PropertyGroup
 
 from ...components.utils import is_gpu_available
 
-from ...preferences import Preference, get_addon_pref
+from ...preferences import HubsPreference, get_addon_pref
 
 from ..components_registry import get_components_registry
 from ..hubs_component import HubsComponent
@@ -157,7 +157,7 @@ class BakeProbeOperator(bpy.types.Operator):
                     image_name = "generated_cubemap-%s" % probe.name
                     img = bpy.data.images.get(image_name)
                     img_path = "%s/%s.hdr" % (get_addon_pref(
-                        Preference.TMP_PATH), probe.name)
+                        HubsPreference.TMP_PATH), probe.name)
                     if not img:
                         img = bpy.data.images.load(filepath=img_path)
                         img.name = image_name
@@ -229,7 +229,7 @@ class BakeProbeOperator(bpy.types.Operator):
         bpy.context.scene.render.resolution_y = y
         bpy.context.scene.render.image_settings.file_format = "HDR"
         bpy.context.scene.render.filepath = "%s/%s.hdr" % (
-            get_addon_pref(Preference.TMP_PATH), self.probe.name)
+            get_addon_pref(HubsPreference.TMP_PATH), self.probe.name)
 
         # TODO don't clobber renderer properties
         # TODO handle skipping compositor

--- a/addons/io_hubs_addon/components/definitions/reflection_probe.py
+++ b/addons/io_hubs_addon/components/definitions/reflection_probe.py
@@ -74,6 +74,7 @@ class BakeProbeOperator(bpy.types.Operator):
     rendering = False
     cancelled = False
     probes = []
+    post_render_wait = 0
 
     @ classmethod
     def poll(cls, context):
@@ -120,6 +121,7 @@ class BakeProbeOperator(bpy.types.Operator):
         self.cancelled = False
         self.done = False
         self.rendering = False
+        self.post_render_wait = 500
         self.probe = self.probes.pop(-1)
 
         return {"RUNNING_MODAL"}
@@ -171,6 +173,13 @@ class BakeProbeOperator(bpy.types.Operator):
                 return {"FINISHED"}
 
             elif not self.rendering:
+                # There seems to be some sort of deadlock if we don't wait some time time between renders.
+                # It would be nice to get to the bottom of this.
+                if self.post_render_wait < 500:
+                    self.post_render_wait += 500
+                    return {"PASS_THROUGH"}
+                else:
+                    self.post_render_wait = 0
                 try:
                     self.rendering = True
                     self.render_probe(context)

--- a/addons/io_hubs_addon/components/hubs_component.py
+++ b/addons/io_hubs_addon/components/hubs_component.py
@@ -106,6 +106,10 @@ class HubsComponent(PropertyGroup):
         pass
 
     @classmethod
+    def draw_global(cls, context, layout, panel_type):
+        '''Draw method to be called by the panel. This can be used to draw global component properties in a panel before the component properties.'''
+
+    @classmethod
     def get_properties(cls):
         if hasattr(cls, '__annotations__'):
             return cls.__annotations__.keys()

--- a/addons/io_hubs_addon/components/operators.py
+++ b/addons/io_hubs_addon/components/operators.py
@@ -6,7 +6,7 @@ from functools import reduce
 from .types import PanelType
 from .utils import get_object_source, dash_to_title, has_component, add_component, remove_component
 from .components_registry import get_components_registry, get_components_icons
-from ..preferences import Preference, get_addon_pref
+from ..preferences import HubsPreference, get_addon_pref
 
 
 class AddHubsComponent(Operator):
@@ -54,7 +54,7 @@ class AddHubsComponent(Operator):
 
         def draw(self, context):
             added_comps = 0
-            row_length = get_addon_pref(Preference.ROW_LENGTH)
+            row_length = get_addon_pref(HubsPreference.ROW_LENGTH)
             row = self.layout.row()
 
             column_sorted_category_components = {}

--- a/addons/io_hubs_addon/components/operators.py
+++ b/addons/io_hubs_addon/components/operators.py
@@ -6,6 +6,7 @@ from functools import reduce
 from .types import PanelType
 from .utils import get_object_source, dash_to_title, has_component, add_component, remove_component
 from .components_registry import get_components_registry, get_components_icons
+from ..preferences import Preference, get_addon_pref
 
 
 class AddHubsComponent(Operator):
@@ -53,7 +54,7 @@ class AddHubsComponent(Operator):
 
         def draw(self, context):
             added_comps = 0
-            row_length = bpy.context.preferences.addons[__package__.split('.')[0]].preferences.row_length
+            row_length = get_addon_pref(Preference.ROW_LENGTH)
             row = self.layout.row()
 
             column_sorted_category_components = {}
@@ -64,21 +65,26 @@ class AddHubsComponent(Operator):
             for cat_idx, category_cmps in enumerate(sorted(components_by_category.items())):
                 # add a tuple of the categories and components to the proper column index based on row length
                 try:
-                    column_sorted_category_components[cat_idx % row_length].append(category_cmps)
+                    column_sorted_category_components[cat_idx % row_length].append(
+                        category_cmps)
                 except KeyError:
-                    column_sorted_category_components[cat_idx % row_length] = [category_cmps]
+                    column_sorted_category_components[cat_idx % row_length] = [
+                        category_cmps]
                 # if the row length is zero, then just add a column for each category
                 except ZeroDivisionError:
-                    column_sorted_category_components[cat_idx] = [category_cmps]
+                    column_sorted_category_components[cat_idx] = [
+                        category_cmps]
 
                 # get the number of components in this category
                 cmp_len = len(category_cmps[1])
 
                 # get which row we're on
                 try:
-                    row_idx = len(column_sorted_category_components[cat_idx % row_length]) - 1
+                    row_idx = len(
+                        column_sorted_category_components[cat_idx % row_length]) - 1
                 except ZeroDivisionError:
-                    row_idx = len(column_sorted_category_components[cat_idx]) - 1
+                    row_idx = len(
+                        column_sorted_category_components[cat_idx]) - 1
 
                 # update the maximum number of components in a category for this row
                 try:

--- a/addons/io_hubs_addon/components/operators.py
+++ b/addons/io_hubs_addon/components/operators.py
@@ -6,7 +6,7 @@ from functools import reduce
 from .types import PanelType
 from .utils import get_object_source, dash_to_title, has_component, add_component, remove_component
 from .components_registry import get_components_registry, get_components_icons
-from ..preferences import HubsPreference, get_addon_pref
+from ..preferences import get_addon_pref
 
 
 class AddHubsComponent(Operator):
@@ -54,7 +54,7 @@ class AddHubsComponent(Operator):
 
         def draw(self, context):
             added_comps = 0
-            row_length = get_addon_pref(HubsPreference.ROW_LENGTH)
+            row_length = get_addon_pref(context).row_length
             row = self.layout.row()
 
             column_sorted_category_components = {}

--- a/addons/io_hubs_addon/components/panels.py
+++ b/addons/io_hubs_addon/components/panels.py
@@ -1,7 +1,15 @@
 import bpy
 from .types import PanelType
-from .components_registry import get_component_by_name
+from .components_registry import get_component_by_name, get_components_registry
 from .utils import get_object_source, dash_to_title
+
+
+def draw_component_global(panel, context):
+    layout = panel.layout
+    panel_type = PanelType(panel.bl_context)
+    components_registry = get_components_registry()
+    for _, component_class in components_registry.items():
+        component_class.draw_global(context, layout, panel_type)
 
 
 def draw_component(panel, context, obj, row, component_item):
@@ -98,6 +106,9 @@ class HubsScenePanel(bpy.types.Panel):
     bl_context = 'scene'
 
     def draw(self, context):
+        draw_component_global(self, context)
+        layout = self.layout
+        layout.separator()
         draw_components_list(self, context)
 
 

--- a/addons/io_hubs_addon/components/utils.py
+++ b/addons/io_hubs_addon/components/utils.py
@@ -100,3 +100,8 @@ def children_recursive(ob):
         return ret
     else:
         return ob.children_recursive
+
+
+def is_gpu_available(context):
+    cycles_addon = context.preferences.addons["cycles"]
+    return cycles_addon and cycles_addon.preferences.has_active_device()

--- a/addons/io_hubs_addon/preferences.py
+++ b/addons/io_hubs_addon/preferences.py
@@ -3,15 +3,24 @@ from bpy.types import AddonPreferences
 from bpy.props import IntProperty, StringProperty
 from enum import Enum
 
+from .utils import get_addon_package
+
 
 class HubsPreference(Enum):
     ROW_LENGTH = 'row_length'
     TMP_PATH = 'tmp_path'
 
 
+HUBS_PREFERENCES_DEFAULTS = {
+    HubsPreference.ROW_LENGTH.value: 4,
+    HubsPreference.TMP_PATH.value: "//generated_cubemaps/"
+}
+
+
 def get_addon_pref(pref):
-    return bpy.context.preferences.addons[__package__.split('.')[
-        0]].preferences[pref.value]
+    addon_package = get_addon_package()
+    addon_prefs = bpy.context.preferences.addons[addon_package].preferences
+    return pref.value if pref.value in addon_prefs else HUBS_PREFERENCES_DEFAULTS[pref.value]
 
 
 class HubsPreferences(AddonPreferences):
@@ -20,7 +29,7 @@ class HubsPreferences(AddonPreferences):
     row_length: IntProperty(
         name="Add Component Menu Row Length",
         description="Allows you to control how many categories are added to a row before it starts on the next row. Set to 0 to have it all on one row",
-        default=4,
+        default=HUBS_PREFERENCES_DEFAULTS[HubsPreference.ROW_LENGTH.value],
         min=0,
     )
 
@@ -28,7 +37,7 @@ class HubsPreferences(AddonPreferences):
         name="Temporary files path",
         description="Path where temporary files will be stored.",
         subtype="DIR_PATH",
-        default="//generated_cubemaps/"
+        default=HUBS_PREFERENCES_DEFAULTS[HubsPreference.TMP_PATH.value]
     )
 
     def draw(self, context):

--- a/addons/io_hubs_addon/preferences.py
+++ b/addons/io_hubs_addon/preferences.py
@@ -1,6 +1,18 @@
 import bpy
 from bpy.types import AddonPreferences
-from bpy.props import IntProperty
+from bpy.props import IntProperty, StringProperty
+from enum import Enum
+
+
+class Preference(Enum):
+    ROW_LENGTH = 'row_length'
+    TMP_PATH = 'tmp_path'
+
+
+def get_addon_pref(pref):
+    return bpy.context.preferences.addons[__package__.split('.')[
+        0]].preferences[pref.value]
+
 
 class HubsPreferences(AddonPreferences):
     bl_idname = __package__
@@ -10,17 +22,26 @@ class HubsPreferences(AddonPreferences):
         description="Allows you to control how many categories are added to a row before it starts on the next row. Set to 0 to have it all on one row",
         default=4,
         min=0,
-        )
+    )
+
+    tmp_path: StringProperty(
+        name="Temporary files path",
+        description="Path where temporary files will be stored.",
+        subtype="DIR_PATH",
+        default="//generated_cubemaps/"
+    )
 
     def draw(self, context):
         layout = self.layout
         box = layout.box()
 
         box.row().prop(self, "row_length")
+        box.row().prop(self, "tmp_path")
 
 
 def register():
     bpy.utils.register_class(HubsPreferences)
+
 
 def unregister():
     bpy.utils.unregister_class(HubsPreferences)

--- a/addons/io_hubs_addon/preferences.py
+++ b/addons/io_hubs_addon/preferences.py
@@ -20,7 +20,7 @@ HUBS_PREFERENCES_DEFAULTS = {
 def get_addon_pref(pref):
     addon_package = get_addon_package()
     addon_prefs = bpy.context.preferences.addons[addon_package].preferences
-    return pref.value if pref.value in addon_prefs else HUBS_PREFERENCES_DEFAULTS[pref.value]
+    return addon_prefs[pref.value] if pref.value in addon_prefs else HUBS_PREFERENCES_DEFAULTS[pref.value]
 
 
 class HubsPreferences(AddonPreferences):

--- a/addons/io_hubs_addon/preferences.py
+++ b/addons/io_hubs_addon/preferences.py
@@ -11,16 +11,10 @@ class HubsPreference(Enum):
     TMP_PATH = 'tmp_path'
 
 
-HUBS_PREFERENCES_DEFAULTS = {
-    HubsPreference.ROW_LENGTH.value: 4,
-    HubsPreference.TMP_PATH.value: "//generated_cubemaps/"
-}
-
-
 def get_addon_pref(pref):
     addon_package = get_addon_package()
     addon_prefs = bpy.context.preferences.addons[addon_package].preferences
-    return addon_prefs[pref.value] if pref.value in addon_prefs else HUBS_PREFERENCES_DEFAULTS[pref.value]
+    return getattr(addon_prefs, pref.value)
 
 
 class HubsPreferences(AddonPreferences):
@@ -29,7 +23,7 @@ class HubsPreferences(AddonPreferences):
     row_length: IntProperty(
         name="Add Component Menu Row Length",
         description="Allows you to control how many categories are added to a row before it starts on the next row. Set to 0 to have it all on one row",
-        default=HUBS_PREFERENCES_DEFAULTS[HubsPreference.ROW_LENGTH.value],
+        default=4,
         min=0,
     )
 
@@ -37,7 +31,7 @@ class HubsPreferences(AddonPreferences):
         name="Temporary files path",
         description="Path where temporary files will be stored.",
         subtype="DIR_PATH",
-        default=HUBS_PREFERENCES_DEFAULTS[HubsPreference.TMP_PATH.value]
+        default="//generated_cubemaps/"
     )
 
     def draw(self, context):

--- a/addons/io_hubs_addon/preferences.py
+++ b/addons/io_hubs_addon/preferences.py
@@ -4,7 +4,7 @@ from bpy.props import IntProperty, StringProperty
 from enum import Enum
 
 
-class Preference(Enum):
+class HubsPreference(Enum):
     ROW_LENGTH = 'row_length'
     TMP_PATH = 'tmp_path'
 

--- a/addons/io_hubs_addon/preferences.py
+++ b/addons/io_hubs_addon/preferences.py
@@ -6,15 +6,9 @@ from enum import Enum
 from .utils import get_addon_package
 
 
-class HubsPreference(Enum):
-    ROW_LENGTH = 'row_length'
-    TMP_PATH = 'tmp_path'
-
-
-def get_addon_pref(pref):
+def get_addon_pref(context):
     addon_package = get_addon_package()
-    addon_prefs = bpy.context.preferences.addons[addon_package].preferences
-    return getattr(addon_prefs, pref.value)
+    return context.preferences.addons[addon_package].preferences
 
 
 class HubsPreferences(AddonPreferences):

--- a/addons/io_hubs_addon/utils.py
+++ b/addons/io_hubs_addon/utils.py
@@ -1,0 +1,2 @@
+def get_addon_package():
+    return __package__


### PR DESCRIPTION
This PR moves the reflection probes environment resolution and bake button to the scene panel as global properties. Now all reflection probes will use the same env map resolution. Also:

- Adds support for multiple reflection probe env map renders
- Improves error handling and logging during baking reporting to the info area
- Saves/restores previous render settings after the baking finishes
- Adds a preference to customize a global tmp path to store all addon generated temporary files
- Adds a new hubs component method to allow components to draw global properties in any panel (for now it mostly makes sense in the scene one). The global properties are drawn before the component blocks.