### PR TITLE
Fix Gizmo Issues

### DIFF
--- a/addons/io_hubs_addon/components/gizmos.py
+++ b/addons/io_hubs_addon/components/gizmos.py
@@ -264,6 +264,8 @@ def register_functions():
 
         bpy.types.Armature.hubs_old_bones_length = IntProperty(options={'HIDDEN', 'SKIP_SAVE'})
 
+        register_gizmo_system()
+
     def unregister():
         if load_post in bpy.app.handlers.load_post:
             bpy.app.handlers.load_post.remove(load_post)

--- a/addons/io_hubs_addon/components/gizmos.py
+++ b/addons/io_hubs_addon/components/gizmos.py
@@ -1,5 +1,7 @@
 import bpy
+import bpy_types
 from bpy.types import (Gizmo, GizmoGroup)
+from bpy.props import (IntProperty)
 from .components_registry import get_component_by_name
 from bpy.app.handlers import persistent
 from math import radians
@@ -65,88 +67,132 @@ class HubsGizmoGroup(GizmoGroup):
     bl_region_type = 'WINDOW'
     bl_options = {'3D', 'PERSISTENT', 'SHOW_MODAL_ALL', 'SELECT'}
 
-    def add_gizmo(self, ob, name):
-        for component_item in ob.hubs_component_list.items:
+    def add_gizmo(self, ob, host):
+        print('def add_gizmo')
+        for component_item in host.hubs_component_list.items:
+            print('component_item:', component_item)
             component_name = component_item.name
             component_class = get_component_by_name(component_name)
+            print('component_name:', component_name)
+            print('component_class:', component_class)
             if not component_class:
                 continue
-            gizmo = component_class.create_gizmo(ob, self)
+            gizmo = component_class.create_gizmo(host, self)
+            print('gizmo:', gizmo)
             if gizmo:
                 if not component_name in self.widgets:
+                    print('add component to widgets')
                     self.widgets[component_name] = {}
-                if name not in self.widgets[component_name]:
-                    self.widgets[component_name][name] = gizmo
+
+                host_key = ob.name+host.name
+                print('host_key:', host_key)
+                if host_key not in self.widgets[component_name]:
+                    print('creating new widget')
+                    self.widgets[component_name][host_key] = {
+                        'ob_name': ob.name,
+                        'host_name': host.name,
+                        'host_type': type(host),
+                        'gizmo': gizmo
+                        }
+                    print('widget:', self.widgets[component_name][host_key])
 
     def setup(self, context):
         self.widgets = {}
 
         for ob in bpy.data.objects:
-            self.add_gizmo(ob, ob.name)
+            self.add_gizmo(ob, ob)
             if ob.type == 'ARMATURE':
                 for bone in ob.data.bones:
-                    self.add_gizmo(bone, bone.name)
+                    self.add_gizmo(ob, bone)
                 for edit_bone in ob.data.edit_bones:
-                    self.add_gizmo(edit_bone, edit_bone.name)
+                    self.add_gizmo(ob, edit_bone)
 
         self.refresh(context)
 
-    def remove_gizmo(self, component_name, ob_name):
-        gizmo = self.widgets[component_name][ob_name]
+    def remove_gizmo(self, component_name, host_key):
+        print('def remove_gizmo')
+        print('component_name:', component_name)
+        print('host_key:', host_key)
+        gizmo = self.widgets[component_name][host_key]['gizmo']
         if gizmo:
             self.gizmos.remove(gizmo)
-        del self.widgets[component_name][ob_name]
+        del self.widgets[component_name][host_key]
 
     def update_gizmo(self, component_name, ob, bone, target, gizmo):
+        print('def update_gizmo')
         component_class = get_component_by_name(component_name)
         component_class.update_gizmo(ob, bone, target, gizmo)
 
     def update_object_gizmo(self, component_name, ob, gizmo):
+        print('update_object_gizmo')
         if component_name not in ob.hubs_component_list.items:
-            self.remove_gizmo(component_name, ob.name)
+            self.remove_gizmo(component_name, ob.name+ob.name)
         else:
             self.update_gizmo(component_name, ob, None, ob, gizmo)
 
     def update_bone_gizmo(self, component_name, ob, bone, pose_bone, gizmo):
+        print('def update_bone_gizmo')
         if component_name not in bone.hubs_component_list.items:
-            self.remove_gizmo(component_name, bone.name)
+            self.remove_gizmo(component_name, ob.name+bone.name)
         else:
             self.update_gizmo(component_name, ob, pose_bone, bone, gizmo)
 
     def refresh(self, context):
+        print('def refresh')
         for component_name in self.widgets:
+            print('component_name:', component_name)
             components_widgets = self.widgets[component_name].copy()
-            for name in components_widgets:
-                gizmo = components_widgets[name]
-                if gizmo and gizmo in self.gizmos.values():
+            for widget in components_widgets.values():
+                print('widget:', widget)
+                if widget['gizmo'] and widget['gizmo'] in self.gizmos.values():
                     found = False
                     for ob in bpy.data.objects:
+                        print('ob:', ob)
+                        if ob.name != widget['ob_name']:
+                            continue
+
+                        print('ob.type:', ob.type)
                         if ob.type == 'ARMATURE':
                             # https://docs.blender.org/api/blender_python_api_2_71_release/info_gotcha.html#editbones-posebones-bone-bones
-                            if context.mode == 'EDIT_ARMATURE':
-                                if name in ob.data.edit_bones:
-                                    bone = ob.data.edit_bones[name]
+                            print('context.mode:', context.mode)
+                            if ob.mode == 'EDIT':
+                                if widget['host_name'] in ob.data.edit_bones:
+                                    bone = ob.data.edit_bones[widget['host_name']]
                                     self.update_bone_gizmo(
-                                        component_name, ob, bone, bone, gizmo)
+                                        component_name, ob, bone, bone, widget['gizmo'])
                                     found = True
+                                    break
                             else:
-                                if name in ob.data.bones:
-                                    bone = ob.data.bones[name]
-                                    pose_bone = ob.pose.bones[name]
+                                if widget['host_name'] in ob.data.bones:
+                                    bone = ob.data.bones[widget['host_name']]
+                                    pose_bone = ob.pose.bones[widget['host_name']]
                                     self.update_bone_gizmo(
-                                        component_name, ob, bone, pose_bone, gizmo)
+                                        component_name, ob, bone, pose_bone, widget['gizmo'])
                                     found = True
+                                    break
 
-                        if name == ob.name:
+                        if widget['host_type'] == bpy_types.Object:
                             self.update_object_gizmo(
-                                component_name, ob, gizmo)
+                                component_name, ob, widget['gizmo'])
                             found = True
+                            break
 
                     if not found:
-                        self.gizmos.remove(gizmo)
+                        print('not found, removing gizmo')
+                        self.gizmos.remove(widget['gizmo'])
 
 
 global objects_count
+ob_handle = object()
+bone_handle = object()
+edit_bone_handle = object()
+
+ob_subscribe_to = (bpy.types.Object, "name")
+bone_subscribe_to = (bpy.types.Bone, "name")
+edit_bone_subscribe_to = (bpy.types.EditBone, "name")
+
+def msgbus_callback(*args):
+    update_gizmos()
 
 
 @persistent
@@ -162,9 +208,15 @@ def redo_post(dummy):
 @persistent
 def depsgraph_update_post(dummy):
     global objects_count
-    if len(bpy.data.objects) != objects_count:
-        update_gizmos()
-    objects_count = len(bpy.data.objects)
+    if bpy.context.mode == 'OBJECT':
+        if len(bpy.data.objects) != objects_count:
+            update_gizmos()
+        objects_count = len(bpy.data.objects)
+    elif bpy.context.mode == 'EDIT_ARMATURE':
+        for ob in bpy.context.objects_in_mode:
+            if len(ob.data.edit_bones) != ob.data.hubs_old_bones_length:
+                update_gizmos()
+            ob.data.hubs_old_bones_length = len(ob.data.edit_bones)
 
 
 @persistent
@@ -172,6 +224,24 @@ def load_post(dummy):
     global objects_count
     objects_count = len(bpy.data.objects)
     update_gizmos()
+    bpy.msgbus.subscribe_rna(
+        key=ob_subscribe_to,
+        owner=ob_handle,
+        args=(bpy.context,),
+        notify=msgbus_callback,
+    )
+    bpy.msgbus.subscribe_rna(
+        key=bone_subscribe_to,
+        owner=bone_handle,
+        args=(bpy.context,),
+        notify=msgbus_callback,
+    )
+    bpy.msgbus.subscribe_rna(
+        key=edit_bone_subscribe_to,
+        owner=edit_bone_handle,
+        args=(bpy.context,),
+        notify=msgbus_callback,
+    )
 
 
 def register_gizmo_classes():
@@ -192,7 +262,6 @@ def update_gizmos():
 
     register_gizmo_classes()
 
-
 def register_functions():
     def register():
         if not load_post in bpy.app.handlers.load_post:
@@ -200,7 +269,36 @@ def register_functions():
         if not depsgraph_update_post in bpy.app.handlers.depsgraph_update_post:
             bpy.app.handlers.depsgraph_update_post.append(
                 depsgraph_update_post)
+        if not undo_post in bpy.app.handlers.undo_post:
+            bpy.app.handlers.undo_post.append(
+                undo_post)
+        if not redo_post in bpy.app.handlers.redo_post:
+            bpy.app.handlers.redo_post.append(
+                redo_post)
+
+        bpy.types.Armature.hubs_old_bones_length = IntProperty(options={'HIDDEN', 'SKIP_SAVE'})
+
         register_gizmo_classes()
+
+        bpy.msgbus.subscribe_rna(
+            key=ob_subscribe_to,
+            owner=ob_handle,
+            args=(bpy.context,),
+            notify=msgbus_callback,
+        )
+        bpy.msgbus.subscribe_rna(
+            key=bone_subscribe_to,
+            owner=bone_handle,
+            args=(bpy.context,),
+            notify=msgbus_callback,
+        )
+        bpy.msgbus.subscribe_rna(
+            key=edit_bone_subscribe_to,
+            owner=edit_bone_handle,
+            args=(bpy.context,),
+            notify=msgbus_callback,
+        )
+
 
     def unregister():
         if load_post in bpy.app.handlers.load_post:
@@ -208,7 +306,20 @@ def register_functions():
         if depsgraph_update_post in bpy.app.handlers.depsgraph_update_post:
             bpy.app.handlers.depsgraph_update_post.remove(
                 depsgraph_update_post)
+        if undo_post in bpy.app.handlers.undo_post:
+            bpy.app.handlers.undo_post.remove(
+                undo_post)
+        if redo_post in bpy.app.handlers.redo_post:
+            bpy.app.handlers.redo_post.remove(
+                redo_post)
+
         unregister_gizmo_classes()
+
+        del bpy.types.Armature.hubs_old_bones_length
+
+        bpy.msgbus.clear_by_owner(ob_handle)
+        bpy.msgbus.clear_by_owner(bone_handle)
+        bpy.msgbus.clear_by_owner(edit_bone_handle)
 
     return register, unregister
 

--- a/addons/io_hubs_addon/components/utils.py
+++ b/addons/io_hubs_addon/components/utils.py
@@ -7,14 +7,10 @@ V_S1 = Vector((1.0, 1.0, 1.0))
 
 
 def add_component(obj, component_name):
-    print('def add_component')
-    print('obj:', obj)
-    print('component_name:', component_name)
     component_item = obj.hubs_component_list.items.add()
     component_item.name = component_name
 
     component_class = get_component_by_name(component_name)
-    print('component_class:', component_class)
     if component_class:
         update_gizmos()
         component_class.init(obj)

--- a/addons/io_hubs_addon/components/utils.py
+++ b/addons/io_hubs_addon/components/utils.py
@@ -7,10 +7,14 @@ V_S1 = Vector((1.0, 1.0, 1.0))
 
 
 def add_component(obj, component_name):
+    print('def add_component')
+    print('obj:', obj)
+    print('component_name:', component_name)
     component_item = obj.hubs_component_list.items.add()
     component_item.name = component_name
 
     component_class = get_component_by_name(component_name)
+    print('component_class:', component_class)
     if component_class:
         update_gizmos()
         component_class.init(obj)


### PR DESCRIPTION
This should fix all the issues with gizmos, plus improve the performance and prevent any performance drain on scenes that aren't using gizmos.  I feel it also simplifies the logic in some places.  Objects are now linked directly with gizmos for fast lookups and shouldn't become stale because the system is re-initialized on any change, this also means that there is no further use of a dedicated remove gizmo function, so it has been removed.  Blender's msgbus system has been employed to trigger a refresh when a gizmo object is renamed (unfortunately bones seem to be too unstable to be subscribed to directly, so a refresh is triggered on any bone rename)

This PR fixes issues:
#83
#84
#85
#86
#87