### PR TITLE
Fix Loop Animation Component Issues

### DIFF
--- a/addons/io_hubs_addon/components/definitions/ammo_shape.py
+++ b/addons/io_hubs_addon/components/definitions/ammo_shape.py
@@ -68,8 +68,8 @@ class AmmoShape(HubsComponent):
         description="Include invisible objects when generating a collider. (Only used if \"fit\" is set to \"all\")",
         default=False)
 
-    def draw(self, context, layout, panel_type):
-        super().draw(context, layout, panel_type)
+    def draw(self, context, layout, panel):
+        super().draw(context, layout, panel)
 
         parents = [context.object]
         while parents:

--- a/addons/io_hubs_addon/components/definitions/audio_target.py
+++ b/addons/io_hubs_addon/components/definitions/audio_target.py
@@ -121,7 +121,7 @@ class AudioTarget(HubsComponent):
         description="Show debug visuals",
         default=False)
 
-    def draw(self, context, layout, panel_type):
+    def draw(self, context, layout, panel):
         from .audio_source import AudioSource
         dep_name = AudioSource.get_name()
 

--- a/addons/io_hubs_addon/components/definitions/loop_animation.py
+++ b/addons/io_hubs_addon/components/definitions/loop_animation.py
@@ -50,7 +50,8 @@ class AddTrackOperator(Operator):
         track = host.hubs_component_loop_animation.tracks_list.add()
         track.name = self.track_name
 
-        host.hubs_component_loop_animation.active_track_key += 1
+        num_tracks = len(host.hubs_component_loop_animation.tracks_list)
+        host.hubs_component_loop_animation.active_track_key = num_tracks - 1
 
         return {'FINISHED'}
 

--- a/addons/io_hubs_addon/components/definitions/loop_animation.py
+++ b/addons/io_hubs_addon/components/definitions/loop_animation.py
@@ -35,17 +35,22 @@ class TracksList(bpy.types.UIList):
 class AddTrackOperator(Operator):
     bl_idname = "hubs_loop_animation.add_track"
     bl_label = "Add Track"
+    bl_options = {'REGISTER', 'UNDO'}
 
     track_name: StringProperty(
         name="Track Name", description="Track Name", default="")
 
-    def execute(self, context):
-        ob = context.object
-        if context.mode == 'POSE' or context.mode == 'EDIT_ARMATURE':
-            ob = context.active_bone
+    panel_type: StringProperty(name="panel_type")
 
-        track = ob.hubs_component_loop_animation.tracks_list.add()
+    def execute(self, context):
+        panel_type = PanelType(self.panel_type)
+        ob = context.object
+        host = ob if panel_type == PanelType.OBJECT else context.active_bone
+
+        track = host.hubs_component_loop_animation.tracks_list.add()
         track.name = self.track_name
+
+        host.hubs_component_loop_animation.active_track_key += 1
 
         return {'FINISHED'}
 
@@ -56,19 +61,30 @@ class AddTrackOperator(Operator):
 class RemoveTrackOperator(Operator):
     bl_idname = "hubs_loop_animation.remove_track"
     bl_label = "Remove Track"
+    bl_options = {'REGISTER', 'UNDO'}
 
     @classmethod
-    def poll(self, context):
-        return context.object.hubs_component_loop_animation.active_track_key != -1
+    def poll(cls, context):
+        panel_type = PanelType(context.panel.bl_context)
+        ob = context.object
+        host = ob if panel_type == PanelType.OBJECT else context.active_bone
+
+        return host.hubs_component_loop_animation.active_track_key != -1
 
     def execute(self, context):
+        panel_type = PanelType(context.panel.bl_context)
         ob = context.object
-        if context.mode == 'POSE' or context.mode == 'EDIT_ARMATURE':
-            ob = context.active_bone
+        host = ob if panel_type == PanelType.OBJECT else context.active_bone
 
-        active_track_key = ob.hubs_component_loop_animation.active_track_key
-        ob.hubs_component_loop_animation.tracks_list.remove(
+        active_track_key = host.hubs_component_loop_animation.active_track_key
+        host.hubs_component_loop_animation.tracks_list.remove(
             active_track_key)
+
+        if host.hubs_component_loop_animation.active_track_key != 0:
+            host.hubs_component_loop_animation.active_track_key -= 1
+
+        if len(host.hubs_component_loop_animation.tracks_list) == 0:
+            host.hubs_component_loop_animation.active_track_key = -1
 
         return {'FINISHED'}
 
@@ -88,20 +104,26 @@ class TracksContextMenu(Menu):
     bl_label = "Tracks Specials"
 
     def draw(self, context):
+        panel_type = PanelType(context.panel.bl_context)
         no_tracks = True
         ob = context.object
+        host = ob if panel_type == PanelType.OBJECT else context.active_bone
         if ob.animation_data:
             for _, a in enumerate(ob.animation_data.nla_tracks):
-                if not has_track(context.object.hubs_component_loop_animation.tracks_list, a.name):
-                    self.layout.operator(AddTrackOperator.bl_idname, icon='OBJECT_DATA',
-                                         text=a.name).track_name = a.name
+                if not has_track(host.hubs_component_loop_animation.tracks_list, a.name):
+                    add_track = self.layout.operator(AddTrackOperator.bl_idname, icon='OBJECT_DATA',
+                                         text=a.name)
+                    add_track.track_name = a.name
+                    add_track.panel_type = panel_type.value
                     no_tracks = False
 
         if hasattr(ob.data, 'shape_keys') and ob.data.shape_keys and ob.data.shape_keys.animation_data:
             for _, a in enumerate(ob.data.shape_keys.animation_data.nla_tracks):
                 if not has_track(context.object.hubs_component_loop_animation.tracks_list, a.name):
-                    self.layout.operator(AddTrackOperator.bl_idname, icon='OBJECT_DATA',
-                                         text=a.name).track_name = a.name
+                    add_track = self.layout.operator(AddTrackOperator.bl_idname, icon='OBJECT_DATA',
+                                         text=a.name)
+                    add_track.track_name = a.name
+                    add_track.panel_type = panel_type.value
                     no_tracks = False
 
         if no_tracks:
@@ -155,7 +177,7 @@ class LoopAnimation(HubsComponent):
         default=False
     )
 
-    def draw(self, context, layout, panel_type):
+    def draw(self, context, layout, panel):
         layout.label(text='Animations to play:')
 
         row = layout.row()
@@ -164,6 +186,7 @@ class LoopAnimation(HubsComponent):
 
         col = row.column(align=True)
 
+        col.context_pointer_set('panel', panel)
         col.menu(TracksContextMenu.bl_idname, icon='ADD', text="")
         col.operator(RemoveTrackOperator.bl_idname,
                      icon='REMOVE', text="")

--- a/addons/io_hubs_addon/components/definitions/media_frame.py
+++ b/addons/io_hubs_addon/components/definitions/media_frame.py
@@ -159,8 +159,8 @@ class MediaFrame(HubsComponent):
             'snapToCenter': self.snapToCenter
         }
 
-    def draw(self, context, layout, panel_type):
-        super().draw(context, layout, panel_type)
+    def draw(self, context, layout, panel):
+        super().draw(context, layout, panel)
 
         parents = [context.object]
         while parents:

--- a/addons/io_hubs_addon/components/definitions/morph_audio_feedback.py
+++ b/addons/io_hubs_addon/components/definitions/morph_audio_feedback.py
@@ -104,7 +104,7 @@ class MorphAudioFeedback(HubsComponent):
                     if not component.name in list_ids:
                         component.name = component.name
 
-    def draw(self, context, layout, panel_type):
+    def draw(self, context, layout, panel):
         layout.prop(data=self, property="shape_key")
         shape_keys = context.object.data.shape_keys
         if self.shape_key != BLANK_ID and shape_keys and self.shape_key not in shape_keys.key_blocks:

--- a/addons/io_hubs_addon/components/definitions/networked.py
+++ b/addons/io_hubs_addon/components/definitions/networked.py
@@ -20,7 +20,7 @@ class Networked(HubsComponent):
         default=str(uuid.uuid4()).upper()
     )
 
-    def draw(self, context, layout, panel_type):
+    def draw(self, context, layout, panel):
         layout.label(text="Network ID:")
         layout.label(text=self.id)
 

--- a/addons/io_hubs_addon/components/definitions/reflection_probe.py
+++ b/addons/io_hubs_addon/components/definitions/reflection_probe.py
@@ -307,11 +307,11 @@ class ReflectionProbe(HubsComponent):
         type=Image
     )
 
-    def draw(self, context, layout, panel_type):
+    def draw(self, context, layout, panel):
         row = layout.row()
         row.label(text="Resolution settings, as well as the option to bake all reflection probes at once, can be accessed from the scene settings.",
                   icon='INFO')
-        super().draw(context, layout, panel_type)
+        super().draw(context, layout, panel)
 
         global bake_mode
         bake_msg = "Baking..." if probe_baking and bake_mode == 'ACTIVE' else "Bake"

--- a/addons/io_hubs_addon/components/definitions/reflection_probe.py
+++ b/addons/io_hubs_addon/components/definitions/reflection_probe.py
@@ -337,7 +337,8 @@ class ReflectionProbe(HubsComponent):
         }
 
     @ classmethod
-    def draw_global(cls, context, layout, panel_type):
+    def draw_global(cls, context, layout, panel):
+        panel_type = PanelType(panel.bl_context)
         if len(get_probes()) > 0 and panel_type == PanelType.SCENE:
             row = layout.row()
             col = row.box().column()

--- a/addons/io_hubs_addon/components/definitions/uv_scroll.py
+++ b/addons/io_hubs_addon/components/definitions/uv_scroll.py
@@ -25,14 +25,14 @@ class UVScroll(HubsComponent):
                                    subtype="XYZ",
                                    default=[0, 0])
 
-    def draw(self, context, layout, panel_type):
+    def draw(self, context, layout, panel):
         has_texture = False
         for material in context.object.data.materials:
             for node in material.node_tree.nodes:
                 if node.type == 'TEX_IMAGE':
                     has_texture = True
 
-        super().draw(context, layout, panel_type)
+        super().draw(context, layout, panel)
         if not has_texture:
             layout.alert = True
             layout.label(text='This component requires a texture',

--- a/addons/io_hubs_addon/components/definitions/video_texture_source.py
+++ b/addons/io_hubs_addon/components/definitions/video_texture_source.py
@@ -32,9 +32,9 @@ class VideoTextureSource(HubsComponent):
             return [x for x in children_recursive(ob) if x.type == "CAMERA" and x.parent_bone == bone.name]
         return False
 
-    def draw(self, context, layout, panel_type):
-        super().draw(context, layout, panel_type)
-        if not VideoTextureSource.poll(context, panel_type):
+    def draw(self, context, layout, panel):
+        super().draw(context, layout, panel)
+        if not VideoTextureSource.poll(context, PanelType(panel.bl_context)):
             col = layout.column()
             col.alert = True
             col.label(text='No camera found in the object hierarchy',

--- a/addons/io_hubs_addon/components/definitions/video_texture_target.py
+++ b/addons/io_hubs_addon/components/definitions/video_texture_target.py
@@ -105,7 +105,7 @@ class VideoTextureTarget(HubsComponent):
         default=BLANK_ID,
         options={'HIDDEN'})
 
-    def draw(self, context, layout, panel_type):
+    def draw(self, context, layout, panel):
         from .video_texture_source import VideoTextureSource
         dep_name = VideoTextureSource.get_name()
 

--- a/addons/io_hubs_addon/components/hubs_component.py
+++ b/addons/io_hubs_addon/components/hubs_component.py
@@ -106,7 +106,7 @@ class HubsComponent(PropertyGroup):
         pass
 
     @classmethod
-    def draw_global(cls, context, layout, panel_type):
+    def draw_global(cls, context, layout, panel):
         '''Draw method to be called by the panel. This can be used to draw global component properties in a panel before the component properties.'''
 
     @classmethod

--- a/addons/io_hubs_addon/components/hubs_component.py
+++ b/addons/io_hubs_addon/components/hubs_component.py
@@ -87,7 +87,7 @@ class HubsComponent(PropertyGroup):
             raise Exception(
                 'HubsComponent is an abstract class and cannot be instantiated directly')
 
-    def draw(self, context, layout, panel_type):
+    def draw(self, context, layout, panel):
         '''Draw method to be called by the panel. The base class method will print all the component properties'''
         for key in self.__annotations__.keys():
             if not self.bl_rna.properties[key].is_hidden:

--- a/addons/io_hubs_addon/components/panels.py
+++ b/addons/io_hubs_addon/components/panels.py
@@ -49,7 +49,7 @@ def draw_component(panel, context, obj, row, component_item):
             remove_component_operator.panel_type = panel.bl_context
 
         if has_properties and component_item.expanded:
-            component.draw(context, col, panel_type)
+            component.draw(context, col, panel)
 
     else:
         col = row.box().column()

--- a/addons/io_hubs_addon/components/panels.py
+++ b/addons/io_hubs_addon/components/panels.py
@@ -6,10 +6,9 @@ from .utils import get_object_source, dash_to_title
 
 def draw_component_global(panel, context):
     layout = panel.layout
-    panel_type = PanelType(panel.bl_context)
     components_registry = get_components_registry()
     for _, component_class in components_registry.items():
-        component_class.draw_global(context, layout, panel_type)
+        component_class.draw_global(context, layout, panel)
 
 
 def draw_component(panel, context, obj, row, component_item):


### PR DESCRIPTION
Fixes #93 

Uses the panel type to specify which component (object or bone) the operators should act on.
`context_pointer_set` is used to pass the panel to the menu and the remove track operator (the poll function can't access operator arguments).

The item selection behavior has been changed to match the default behavior.

I've also changed the new draw_global method to take the panel instead of the panel type in case it needs to be passed via  `context_pointer_set` in the future.