### PR TITLE
Fix morph-audio-feedback initial missing shape key warning

### DIFF
--- a/addons/io_hubs_addon/components/definitions/morph_audio_feedback.py
+++ b/addons/io_hubs_addon/components/definitions/morph_audio_feedback.py
@@ -70,7 +70,8 @@ class MorphAudioFeedback(HubsComponent):
 
     name: StringProperty(
         name="Name",
-        description="Name"
+        description="Name",
+        default=BLANK_ID
     )
 
     shape_key: EnumProperty(


### PR DESCRIPTION
Fix the erroneous warning being shown initially in the morph-audio-feedback component's Shape Key menu.