### PR TITLE
Replace atexit with explicit module register/unregister methods

### DIFF
--- a/addons/io_hubs_addon/components/components_registry.py
+++ b/addons/io_hubs_addon/components/components_registry.py
@@ -102,6 +102,8 @@ def load_components_registry():
     for module in get_component_definitions():
         for _, member in inspect.getmembers(module):
             if inspect.isclass(member) and issubclass(member, HubsComponent) and member != HubsComponent:
+                if hasattr(module, 'register_module'):
+                    module.register_module()
                 register_component(member)
                 __components_registry[member.get_name()] = member
 
@@ -111,6 +113,9 @@ def unload_components_registry():
     global __components_registry
     for _, component_class in __components_registry.items():
         unregister_component(component_class)
+    for module in get_component_definitions():
+        if hasattr(module, 'unregister_module'):
+            module.unregister_module()
 
 
 def load_icons():

--- a/addons/io_hubs_addon/components/definitions/loop_animation.py
+++ b/addons/io_hubs_addon/components/definitions/loop_animation.py
@@ -1,4 +1,3 @@
-import atexit
 import bpy
 from bpy.props import StringProperty, CollectionProperty, IntProperty, BoolProperty
 from bpy.types import PropertyGroup, Menu, Operator
@@ -116,14 +115,6 @@ class TrackPropertyType(PropertyGroup):
     )
 
 
-bpy.utils.register_class(TrackPropertyType)
-
-
-@atexit.register
-def unregister():
-    bpy.utils.unregister_class(TrackPropertyType)
-
-
 class LoopAnimation(HubsComponent):
     _definition = {
         'name': 'loop-animation',
@@ -210,3 +201,11 @@ class LoopAnimation(HubsComponent):
                 if ob.type == 'ARMATURE':
                     for bone in ob.data.bones:
                         migrate_data(bone)
+
+
+def register_module():
+    bpy.utils.register_class(TrackPropertyType)
+
+
+def unregister_module():
+    bpy.utils.unregister_class(TrackPropertyType)


### PR DESCRIPTION
I usually get exceptions running test when calling `atexit`. This PRs replaces `atexit` with a more explicit `register_module` and `unregister_module` methods that will be called before the component class is registered to give the module a chance to register classes that the component might require but that need to be loaded before Blender's runtime calls the class' `register`/`unregister` methods.