### PR TITLE
Disable compostior and don't clobber settings during reflection probe baking

### DIFF
--- a/addons/io_hubs_addon/components/definitions/reflection_probe.py
+++ b/addons/io_hubs_addon/components/definitions/reflection_probe.py
@@ -153,15 +153,6 @@ class BakeProbeOperator(bpy.types.Operator):
             'Temp EnvMap Camera', self.camera_data)
         bpy.context.scene.collection.objects.link(self.camera_object)
 
-        self.prev_render_camera = bpy.context.scene.camera
-        self.prev_render_engine = bpy.context.scene.render.engine
-        self.prev_cycles_device = bpy.context.scene.cycles.device
-        self.prev_render_rex_x = bpy.context.scene.render.resolution_x
-        self.prev_render_res_y = bpy.context.scene.render.resolution_y
-        self.prev_render_res_percent = bpy.context.scene.render.resolution_percentage
-        self.prev_render_file_format = bpy.context.scene.render.image_settings.file_format
-        self.prev_render_file_path = bpy.context.scene.render.filepath
-
         modes = {
             'ACTIVE': lambda: [context.active_object],
             'SELECTED': lambda: [ob for ob in get_probes() if ob in context.selected_objects],
@@ -169,6 +160,7 @@ class BakeProbeOperator(bpy.types.Operator):
         }
         self.probes = modes[self.bake_mode]()
 
+        self.saved_props = {}
         self.cancelled = False
         self.done = False
         self.rendering = False
@@ -197,7 +189,6 @@ class BakeProbeOperator(bpy.types.Operator):
                 if self.cancelled:
                     self.report(
                         {'WARNING'}, 'Reflection probe baking cancelled')
-                    self.restore_render_props()
                     return {"CANCELLED"}
 
                 for probe in self.probes:
@@ -219,7 +210,6 @@ class BakeProbeOperator(bpy.types.Operator):
                 props.render_resolution = props.resolution
 
                 self.report({'INFO'}, 'Reflection probe baking finished')
-                self.restore_render_props()
                 return {"FINISHED"}
 
             elif not self.rendering:
@@ -242,14 +232,8 @@ class BakeProbeOperator(bpy.types.Operator):
         return {"PASS_THROUGH"}
 
     def restore_render_props(self):
-        bpy.context.scene.camera = self.prev_render_camera
-        bpy.context.scene.render.engine = self.prev_render_engine
-        bpy.context.scene.cycles.device = self.prev_cycles_device
-        bpy.context.scene.render.resolution_x = self.prev_render_rex_x
-        bpy.context.scene.render.resolution_y = self.prev_render_res_y
-        bpy.context.scene.render.resolution_percentage = self.prev_render_res_percent
-        bpy.context.scene.render.image_settings.file_format = self.prev_render_file_format
-        bpy.context.scene.render.filepath = self.prev_render_file_path
+        for prop in self.saved_props:
+           rsetattr(bpy.context, prop, self.saved_props[prop])
 
     def render_probe(self, context):
         probe = self.probes[self.probe_index]
@@ -273,7 +257,6 @@ class BakeProbeOperator(bpy.types.Operator):
         (x, y) = [int(i) for i in resolution.split('x')]
         output_path = "%s/%s.hdr" % (get_addon_pref(context).tmp_path, probe.name)
 
-        saved_props = {}
         overrides = [
             ("preferences.view.render_display_type", "NONE"),
             ("scene.camera", self.camera_object),
@@ -289,14 +272,12 @@ class BakeProbeOperator(bpy.types.Operator):
         ]
 
         for (prop, value) in overrides:
-           saved_props[prop] = rgetattr(bpy.context, prop)
-           rsetattr(bpy.context, prop, value)
+            if prop not in self.saved_props:
+                self.saved_props[prop] = rgetattr(bpy.context, prop)
+            rsetattr(bpy.context, prop, value)
 
         self.report({'INFO'}, 'Baking probe %s' % probe.name)
         bpy.ops.render.render("INVOKE_DEFAULT", write_still=True)
-
-        for prop in saved_props:
-           rsetattr(bpy.context, prop, saved_props[prop])
 
 class ReflectionProbe(HubsComponent):
     _definition = {

--- a/addons/io_hubs_addon/utils.py
+++ b/addons/io_hubs_addon/utils.py
@@ -1,2 +1,13 @@
 def get_addon_package():
     return __package__
+
+import functools
+
+def rsetattr(obj, attr, val):
+    pre, _, post = attr.rpartition('.')
+    return setattr(rgetattr(obj, pre) if pre else obj, post, val)
+
+def rgetattr(obj, attr, *args):
+    def _getattr(obj, attr):
+        return getattr(obj, attr, *args)
+    return functools.reduce(_getattr, [obj] + attr.split('.'))


### PR DESCRIPTION
This implements 2 todos that were sitting in the reflection probes code that are leading to much pain for artists:
- Disable compositor during reflection probe baking
- Don't clobber render settings

With this fix it should not matter what the user has their render settings set to before baking. Also, after baking their render settings should be restored to what they were before the bake.