### PR TITLE
Fixes references on node properties

### DIFF
--- a/addons/io_hubs_addon/components/definitions/audio_target.py
+++ b/addons/io_hubs_addon/components/definitions/audio_target.py
@@ -4,7 +4,7 @@ from ..hubs_component import HubsComponent
 from ..utils import has_component
 from ..types import Category, PanelType, NodeType
 from bpy.types import Object
-from ...io.utils import gather_joint_property, gather_node_property
+from ...io.utils import gather_joint_property, gather_node_property, delayed_gather
 
 BLANK_ID = "374e54CMHFCipSk"
 
@@ -151,6 +151,7 @@ class AudioTarget(HubsComponent):
         layout.prop(data=self, property="maxDelay")
         layout.prop(data=self, property="debug")
 
+    @delayed_gather
     def gather(self, export_settings, object):
         return {
             'srcNode': gather_joint_property(export_settings, self.srcNode, self, 'bone') if self.bone_id != BLANK_ID else gather_node_property(

--- a/addons/io_hubs_addon/components/definitions/video_texture_target.py
+++ b/addons/io_hubs_addon/components/definitions/video_texture_target.py
@@ -3,7 +3,7 @@ from ..hubs_component import HubsComponent
 from ..types import Category, PanelType, NodeType
 from ..utils import has_component
 from bpy.types import Object
-from ...io.utils import gather_joint_property, gather_node_property
+from ...io.utils import gather_joint_property, gather_node_property, delayed_gather
 
 BLANK_ID = "pXph8WBzMu9fung"
 
@@ -141,6 +141,7 @@ class VideoTextureTarget(HubsComponent):
             col.label(text='This component requires a material',
                       icon='ERROR')
 
+    @delayed_gather
     def gather(self, export_settings, object):
 
         return {

--- a/addons/io_hubs_addon/io/utils.py
+++ b/addons/io_hubs_addon/io/utils.py
@@ -53,6 +53,14 @@ class HubsExportImage(ExportImage):
         raise Exception(
             "HDR images must be saved as a .hdr file before exporting")
 
+def delayed_gather(func):
+    """ It delays the gather until all resources are available """
+    def wrapper_delayed_gather(*args, **kwargs):
+        def gather():
+            return func(*args, **kwargs)
+        gather.delayed_gather = True
+        return gather
+    return wrapper_delayed_gather
 
 @cached
 def gather_image(blender_image, export_settings):
@@ -172,7 +180,6 @@ def gather_array_property(export_settings, blender_object, target, property_name
 
     return value
 
-
 def gather_node_property(export_settings, blender_object, target, property_name):
     blender_object = getattr(target, property_name)
 
@@ -185,23 +192,23 @@ def gather_node_property(export_settings, blender_object, target, property_name)
                 None,
                 export_settings
             )
-            return {
-                "__mhc_link_type": "node",
-                "index": node
-            }
-        reference = {
-            "__mhc_link_type": "node"
+        else:
+            vtree = export_settings['vtree']
+            vnode = vtree.nodes[next((uuid for uuid in vtree.nodes if (
+                vtree.nodes[uuid].blender_object == blender_object)), None)]
+            node = vnode.node or gltf2_blender_gather_nodes.gather_node(
+                vnode,
+                export_settings
+            )
+
+        return {
+            "__mhc_link_type": "node",
+            "index": node
         }
-        for extension in export_settings['gltf_user_extensions']:
-            references = getattr(extension, "hubs_node_property_references", None)
-            if references is not None:
-                references.setdefault(blender_object, []).append(reference)
-        return reference
     else:
         return None
 
 # PointerProperty doesn't support bones so for now we have to call this manually where using an object pointer
-
 
 def gather_joint_property(export_settings, blender_object, target, property_name):
     joint_name = getattr(target, property_name)

--- a/addons/io_hubs_addon/io/utils.py
+++ b/addons/io_hubs_addon/io/utils.py
@@ -225,7 +225,7 @@ def gather_joint_property(export_settings, blender_object, target, property_name
             vtree = export_settings['vtree']
             vnode = vtree.nodes[next((uuid for uuid in vtree.nodes if (
                 vtree.nodes[uuid].joint == joint)), None)]
-            node = gltf2_blender_gather_joints.gather_joint_vnode(
+            node = vnode.node or gltf2_blender_gather_joints.gather_joint_vnode(
                 vnode,
                 export_settings
             )

--- a/addons/io_hubs_addon/io/utils.py
+++ b/addons/io_hubs_addon/io/utils.py
@@ -189,7 +189,7 @@ def gather_node_property(export_settings, blender_object, target, property_name)
             vtree = export_settings['vtree']
             vnode = vtree.nodes[next((uuid for uuid in vtree.nodes if (
                 vtree.nodes[uuid].blender_object == blender_object)), None)]
-            node = gltf2_blender_gather_nodes.gather_node(
+            node = vnode.node or gltf2_blender_gather_nodes.gather_node(
                 vnode,
                 export_settings
             )

--- a/addons/io_hubs_addon/io/utils.py
+++ b/addons/io_hubs_addon/io/utils.py
@@ -185,19 +185,18 @@ def gather_node_property(export_settings, blender_object, target, property_name)
                 None,
                 export_settings
             )
-        else:
-            vtree = export_settings['vtree']
-            vnode = vtree.nodes[next((uuid for uuid in vtree.nodes if (
-                vtree.nodes[uuid].blender_object == blender_object)), None)]
-            node = vnode.node or gltf2_blender_gather_nodes.gather_node(
-                vnode,
-                export_settings
-            )
-
-        return {
-            "__mhc_link_type": "node",
-            "index": node
+            return {
+                "__mhc_link_type": "node",
+                "index": node
+            }
+        reference = {
+            "__mhc_link_type": "node"
         }
+        for extension in export_settings['gltf_user_extensions']:
+            references = getattr(extension, "hubs_node_property_references", None)
+            if references is not None:
+                references.setdefault(blender_object, []).append(reference)
+        return reference
     else:
         return None
 


### PR DESCRIPTION
The vTree is pregenerated so it should already have all the node references. For each reference it was creating a new node causing duplicates at export. Previous version of gltf-exporter (3.1) had a cache that prevented this.

This should fix #81 