### PR TITLE
Don't modify viewpoert visibility from Visible component

### DIFF
--- a/addons/io_hubs_addon/components/definitions/visible.py
+++ b/addons/io_hubs_addon/components/definitions/visible.py
@@ -3,11 +3,6 @@ from bpy.props import BoolProperty
 from ..hubs_component import HubsComponent
 from ..types import Category, PanelType, NodeType
 
-
-def update(self, context):
-    context.object.hide_viewport = not bpy.context.object.hubs_component_visible.visible
-
-
 class Visible(HubsComponent):
     _definition = {
         'name': 'visible',
@@ -18,4 +13,4 @@ class Visible(HubsComponent):
         'icon': 'HIDE_OFF'
     }
 
-    visible: BoolProperty(name="Visible", default=True, update=update)
+    visible: BoolProperty(name="Visible", default=True)


### PR DESCRIPTION
The behavior seems to be more confusing then helpful, so just removing it for now. We can explore other useful ways of indicating that this component is on an object if we find it necessary.