### PR TITLE
Conditional UI for audio-params properties

### DIFF
--- a/addons/io_hubs_addon/components/definitions/audio_params.py
+++ b/addons/io_hubs_addon/components/definitions/audio_params.py
@@ -1,5 +1,5 @@
 import bpy
-from bpy.props import FloatProperty, EnumProperty
+from bpy.props import BoolProperty, FloatProperty, EnumProperty
 from ..hubs_component import HubsComponent
 from ..types import PanelType, NodeType
 from ..consts import DISTACE_MODELS, MAX_ANGLE
@@ -19,6 +19,11 @@ class AudioParams(HubsComponent):
         'panel_type': [PanelType.OBJECT, PanelType.BONE]
     }
 
+    overrideAudioSettings: BoolProperty(
+        name="Override Audio Settings",
+        description="Override Audio Settings",
+        default=False)
+
     audioType: EnumProperty(
         name="Audio Type",
         description="Audio Type",
@@ -37,8 +42,6 @@ class AudioParams(HubsComponent):
         default=1.0,
         min=0.0,
         soft_min=0.0)
-
-    # TODO Add conditional UI to show only the required properties per type
 
     refDistance: FloatProperty(
         name="Ref Distance",
@@ -95,17 +98,18 @@ class AudioParams(HubsComponent):
         soft_min=0.0)
 
     def gather(self, export_settings, object):
-        return {
-            'audioType': self.audioType,
-            'distanceModel': self.distanceModel,
-            'gain': self.gain,
-            'refDistance': self.refDistance,
-            'rolloffFactor': self.rolloffFactor,
-            'maxDistance': self.maxDistance,
-            'coneInnerAngle': round(degrees(self.coneInnerAngle), 2),
-            'coneOuterAngle': round(degrees(self.coneOuterAngle), 2),
-            'coneOuterGain': self.coneOuterGain
-        }
+        if (self.overrideAudioSettings):
+            return {
+                'audioType': self.audioType,
+                'distanceModel': self.distanceModel,
+                'gain': self.gain,
+                'refDistance': self.refDistance,
+                'rolloffFactor': self.rolloffFactor,
+                'maxDistance': self.maxDistance,
+                'coneInnerAngle': round(degrees(self.coneInnerAngle), 2),
+                'coneOuterAngle': round(degrees(self.coneOuterAngle), 2),
+                'coneOuterGain': self.coneOuterGain
+            }
 
     @classmethod
     def migrate(cls, version):
@@ -123,3 +127,20 @@ class AudioParams(HubsComponent):
                 if ob.type == 'ARMATURE':
                     for bone in ob.data.bones:
                         migrate_data(bone)
+
+    def draw(self, context, layout, panel):
+        layout.prop(data=self, property="overrideAudioSettings")
+        if not self.overrideAudioSettings:
+            return
+
+        layout.prop(data=self, property="audioType")
+        layout.prop(data=self, property="gain")
+
+        if self.audioType == "pannernode":
+            layout.prop(data=self, property="distanceModel")
+            layout.prop(data=self, property="rolloffFactor")
+            layout.prop(data=self, property="refDistance")
+            layout.prop(data=self, property="maxDistance")
+            layout.prop(data=self, property="coneInnerAngle")
+            layout.prop(data=self, property="coneOuterAngle")
+            layout.prop(data=self, property="coneOuterGain")


### PR DESCRIPTION
Only show properties and export component if override settings is selected.

Also show available properties according to audio type.

Fixes #91 #92 