### PR TITLE
Set the cutoff version for using "children_recursive" to Blender 3.1 

### DIFF
--- a/addons/io_hubs_addon/components/utils.py
+++ b/addons/io_hubs_addon/components/utils.py
@@ -94,7 +94,7 @@ def children_recurse(ob, result):
 
 
 def children_recursive(ob):
-    if bpy.app.version < (3, 0, 0):
+    if bpy.app.version < (3, 1, 0):
         ret = []
         children_recurse(ob, ret)
         return ret


### PR DESCRIPTION
Blender 3.0 doesn't have the "children_recursive" convenience function.