### PR TITLE
Remove unneeded "soft_min" and "soft_max" parameters.

### DIFF
--- a/addons/io_hubs_addon/components/definitions/audio_params.py
+++ b/addons/io_hubs_addon/components/definitions/audio_params.py
@@ -35,8 +35,7 @@ class AudioParams(HubsComponent):
         name="Gain",
         description="How much to amplify the source audio by",
         default=1.0,
-        min=0.0,
-        soft_min=0.0)
+        min=0.0)
 
     # TODO Add conditional UI to show only the required properties per type
 
@@ -46,15 +45,13 @@ class AudioParams(HubsComponent):
         subtype="DISTANCE",
         unit="LENGTH",
         default=1.0,
-        min=0.0,
-        soft_min=0.0)
+        min=0.0)
 
     rolloffFactor: FloatProperty(
         name="Rolloff Factor",
         description="A double value describing how quickly the volume is reduced as the source moves away from the listener. This value is used by all distance models.",
         default=1.0,
-        min=0.0,
-        soft_min=0.0)
+        min=0.0)
 
     maxDistance: FloatProperty(
         name="Max Distance",
@@ -62,8 +59,7 @@ class AudioParams(HubsComponent):
         subtype="DISTANCE",
         unit="LENGTH",
         default=10000.0,
-        min=0.0,
-        soft_min=0.0)
+        min=0.0)
 
     coneInnerAngle: FloatProperty(
         name="Cone Inner Angle",
@@ -71,9 +67,7 @@ class AudioParams(HubsComponent):
         subtype="ANGLE",
         default=MAX_ANGLE,
         min=0.0,
-        soft_min=0.0,
         max=MAX_ANGLE,
-        soft_max=MAX_ANGLE,
         precision=2)
 
     coneOuterAngle: FloatProperty(
@@ -82,17 +76,14 @@ class AudioParams(HubsComponent):
         subtype="ANGLE",
         default=0.0,
         min=0.0,
-        soft_min=0.0,
         max=MAX_ANGLE,
-        soft_max=MAX_ANGLE,
         precision=2)
 
     coneOuterGain: FloatProperty(
         name="Cone Outer Gain",
         description="A double value describing the amount of volume reduction outside the cone defined by the coneOuterAngle attribute.",
         default=0.0,
-        min=0.0,
-        soft_min=0.0)
+        min=0.0)
 
     def gather(self, export_settings, object):
         return {

--- a/addons/io_hubs_addon/components/definitions/audio_settings.py
+++ b/addons/io_hubs_addon/components/definitions/audio_settings.py
@@ -25,31 +25,27 @@ class AudioSettings(HubsComponent):
     avatarRolloffFactor: FloatProperty(
         name="Avatar Rolloff Factor",
         default=2.0,
-        min=0.0,
-        soft_min=0.0)
+        min=0.0)
 
     avatarRefDistance: FloatProperty(
         name="Avatar Ref Distance",
         description="Avatar Ref Distance",
         subtype="DISTANCE",
         default=1.0,
-        min=0.0,
-        soft_min=0.0)
+        min=0.0)
 
     avatarMaxDistance: FloatProperty(
         name="Avatar Max Distance",
         description="Avatar Max Distance",
         subtype="DISTANCE",
         default=10000.0,
-        min=0.0,
-        soft_min=0.0)
+        min=0.0)
 
     mediaVolume: FloatProperty(
         name="Media Volume",
         description="Media Volume",
         default=0.5,
-        min=0.0,
-        soft_min=0.0)
+        min=0.0)
 
     mediaDistanceModel: EnumProperty(
         name="Media Distance Model",
@@ -61,24 +57,21 @@ class AudioSettings(HubsComponent):
         name="Media Rolloff Factor",
         description="Media Rolloff Factor",
         default=2.0,
-        min=0.0,
-        soft_min=0.0)
+        min=0.0)
 
     mediaRefDistance: FloatProperty(
         name="Media Ref Distance",
         description="Media Rolloff Factor",
         subtype="DISTANCE",
         default=2.0,
-        min=0.0,
-        soft_min=0.0)
+        min=0.0)
 
     mediaMaxDistance: FloatProperty(
         name="Media Max Distance",
         description="Media Max Distance",
         subtype="DISTANCE",
         default=10000.0,
-        min=0.0,
-        soft_min=0.0)
+        min=0.0)
 
     mediaConeInnerAngle: FloatProperty(
         name="Media Cone Inner Angle",
@@ -86,9 +79,7 @@ class AudioSettings(HubsComponent):
         subtype="ANGLE",
         default=MAX_ANGLE,
         min=0.0,
-        soft_min=0.0,
-        max=MAX_ANGLE,
-        soft_max=MAX_ANGLE)
+        max=MAX_ANGLE)
 
     mediaConeOuterAngle: FloatProperty(
         name="Media Cone Outer Angle",
@@ -96,16 +87,13 @@ class AudioSettings(HubsComponent):
         subtype="ANGLE",
         default=0.0,
         min=0.0,
-        soft_min=0.0,
-        max=MAX_ANGLE,
-        soft_max=MAX_ANGLE)
+        max=MAX_ANGLE)
 
     mediaConeOuterGain: FloatProperty(
         name="Media Cone Outer Gain",
         description="Media Cone Outer Gain",
         default=0.0,
-        min=0.0,
-        soft_min=0.0)
+        min=0.0)
 
     def gather(self, export_settings, object):
         return {

--- a/addons/io_hubs_addon/components/definitions/audio_target.py
+++ b/addons/io_hubs_addon/components/definitions/audio_target.py
@@ -106,15 +106,13 @@ class AudioTarget(HubsComponent):
         name="Min Delay",
         description="Minimum random delay applied to the source audio",
         default=0.01,
-        min=0.0,
-        soft_min=0.0)
+        min=0.0)
 
     maxDelay: FloatProperty(
         name="Max Delay",
         description="Maximum random delay applied to the source audio",
         default=0.03,
-        min=0.0,
-        soft_min=0.0)
+        min=0.0)
 
     debug: BoolProperty(
         name="Debug",

--- a/addons/io_hubs_addon/components/definitions/environment_settings.py
+++ b/addons/io_hubs_addon/components/definitions/environment_settings.py
@@ -33,7 +33,7 @@ class EnvironmentSettings(HubsComponent):
         default="LUTToneMapping")
 
     toneMappingExposure: FloatProperty(
-        name="Exposure", description="Exposure level of tone mapping", default=1.0, min=0.0, soft_min=0.0)
+        name="Exposure", description="Exposure level of tone mapping", default=1.0, min=0.0)
 
     backgroundColor: FloatVectorProperty(name="Background Color",
                                          description="Background Color",

--- a/addons/io_hubs_addon/components/definitions/spot_light.py
+++ b/addons/io_hubs_addon/components/definitions/spot_light.py
@@ -40,9 +40,7 @@ class SpotLight(HubsComponent):
         subtype="ANGLE",
         default=0.0,
         min=0.0,
-        soft_min=0.0,
-        max=pi / 2,
-        soft_max=pi / 2)
+        max=pi / 2)
 
     outerConeAngle: FloatProperty(
         name="Cone Outer Angle",
@@ -50,9 +48,7 @@ class SpotLight(HubsComponent):
         subtype="ANGLE",
         default=pi / 4,
         min=0.0,
-        soft_min=0.0,
-        max=pi / 2,
-        soft_max=pi / 2)
+        max=pi / 2)
 
     decay: FloatProperty(name="Decay",
                          description="Decay",


### PR DESCRIPTION
Having the same "soft" min/max as "hard" min/max is redundant. "soft_min" and "soft_max" are used to set guidelines for the user, i.e. if used on a slider they will be unable to go past these values when clicking and dragging, but this doesn't limit what they can type in directly (that's what min and max do, provide a hard limit that you can't bypass).