### PR TITLE
Fix typos, improve docs, and remove trailing periods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You can override the Blender user scripts directory from the console to point to
 
 `BLENDER_USER_SCRIPTS=full_path_to_/hubs-blender-exporter blender`
 
-- ### Symlinking you addon to the Blender user scripts directory
+- ### Symlinking your addon to the Blender user scripts directory
 You can create a symbolic link pointing to `full_path_to_/hubs-blender-exporter/addons/io_hubs_addon` in your current Python scripts directory in Blender. This way you will also load any other addons that you have in that directory.
 
 **MacOS and Linux**

--- a/addons/io_hubs_addon/components/definitions/ammo_shape.py
+++ b/addons/io_hubs_addon/components/definitions/ammo_shape.py
@@ -19,46 +19,46 @@ class AmmoShape(HubsComponent):
         description="Type",
         items=[("box", "Box Collider", "A box-shaped primitive collision shape"),
                ("sphere", "Sphere Collider",
-                "A primitive collision shape which is represents a sphere"),
-               ("hull", "Convex Hull", "A convex hull wrapped around the objects vertices. A good analogy for a convex hull is an elastic membrane or balloon under pressure which is placed around a given set of vertices. When released the membrane will assume the shape of the convex hull."),
-               ("mesh", "Mesh Collider", "A shape made of the actual vertecies of the object. This can be expensive for large meshes.")],
+                "A primitive collision shape which represents a sphere"),
+               ("hull", "Convex Hull", "A convex hull wrapped around the object's vertices. A good analogy for a convex hull is an elastic membrane or balloon under pressure which is placed around a given set of vertices. When released the membrane will assume the shape of the convex hull"),
+               ("mesh", "Mesh Collider", "A shape made of the actual vertices of the object. This can be expensive for large meshes")],
         default="hull")
 
     # TODO Add conditional UI to show only the required properties per type
     fit: EnumProperty(
         name="Shape Fitting Mode",
         description="Shape fitting mode",
-        items=[("all", "Automatic fit all", "Automatically match the shape to fit the object's vertecies"),
-               ("manual", "Manual fit", "Use the manually specified dimensions to define the shape, ignoring the object's vertecies")],
+        items=[("all", "Automatic fit all", "Automatically match the shape to fit the object's vertices"),
+               ("manual", "Manual fit", "Use the manually specified dimensions to define the shape, ignoring the object's vertices")],
         default="all")
 
     halfExtents: FloatVectorProperty(
         name="Half Extents",
-        description="Half dimensions of the collider. (Only used when fit is set to \"manual\" and type is set ot \"box\").",
+        description="Half dimensions of the collider. (Only used when fit is set to \"manual\" and type is set to \"box\")",
         unit='LENGTH',
         subtype="XYZ",
         default=(0.5, 0.5, 0.5))
 
     minHalfExtent: FloatProperty(
         name="Min Half Extent",
-        description="The minimum size to use when automatically generating half extents. (Only used when fit is set to \"all\" and type is set ot \"box\")",
+        description="The minimum size to use when automatically generating half extents. (Only used when fit is set to \"all\" and type is set to \"box\")",
         unit="LENGTH",
         default=0.0)
 
     maxHalfExtent: FloatProperty(
         name="Max Half Extent",
-        description="The maximum size to use when automatically generating half extents. (Only used when fit is set to \"all\" and type is set ot \"box\")",
+        description="The maximum size to use when automatically generating half extents. (Only used when fit is set to \"all\" and type is set to \"box\")",
         unit="LENGTH",
         default=1000.0)
 
     sphereRadius: FloatProperty(
         name="Sphere Radius",
-        description="Radius of the sphere collider. (Only used when fit is set to \"manual\" and type is set ot \"sphere\")",
+        description="Radius of the sphere collider. (Only used when fit is set to \"manual\" and type is set to \"sphere\")",
         unit="LENGTH",
         default=0.5)
 
     offset: FloatVectorProperty(
-        name="Offset", description="An offset to apply to the collider relative to the object's origin.",
+        name="Offset", description="An offset to apply to the collider relative to the object's origin",
         unit='LENGTH',
         subtype="XYZ",
         default=(0.0, 0.0, 0.0))

--- a/addons/io_hubs_addon/components/definitions/audio.py
+++ b/addons/io_hubs_addon/components/definitions/audio.py
@@ -23,7 +23,7 @@ class Audio(HubsComponent):
                            default=True)
 
     controls: BoolProperty(name="Show controls",
-                           description="Show Controls",
+                           description="When enabled, shows play/pause, skip forward/back, and volume controls when hovering your cursor over it in Hubs",
                            default=True)
 
     loop: BoolProperty(name="Loop",

--- a/addons/io_hubs_addon/components/definitions/audio_params.py
+++ b/addons/io_hubs_addon/components/definitions/audio_params.py
@@ -42,7 +42,7 @@ class AudioParams(HubsComponent):
 
     refDistance: FloatProperty(
         name="Ref Distance",
-        description="A double value representing the reference distance for reducing volume as the audio source moves further from the listener. For distances greater than this the volume will be reduced based on rolloffFactor and distanceModel.",
+        description="A double value representing the reference distance for reducing volume as the audio source moves further from the listener. For distances greater than this the volume will be reduced based on rolloffFactor and distanceModel",
         subtype="DISTANCE",
         unit="LENGTH",
         default=1.0,
@@ -51,14 +51,14 @@ class AudioParams(HubsComponent):
 
     rolloffFactor: FloatProperty(
         name="Rolloff Factor",
-        description="A double value describing how quickly the volume is reduced as the source moves away from the listener. This value is used by all distance models.",
+        description="A double value describing how quickly the volume is reduced as the source moves away from the listener. This value is used by all distance models",
         default=1.0,
         min=0.0,
         soft_min=0.0)
 
     maxDistance: FloatProperty(
         name="Max Distance",
-        description="A double value representing the maximum distance between the audio source and the listener, after which the volume is not reduced any further. This value is used only by the linear distance model.",
+        description="A double value representing the maximum distance between the audio source and the listener, after which the volume is not reduced any further. This value is used only by the linear distance model",
         subtype="DISTANCE",
         unit="LENGTH",
         default=10000.0,
@@ -67,7 +67,7 @@ class AudioParams(HubsComponent):
 
     coneInnerAngle: FloatProperty(
         name="Cone Inner Angle",
-        description="A double value describing the angle, in degrees, of a cone inside of which there will be no volume reduction.",
+        description="A double value describing the angle, in degrees, of a cone inside of which there will be no volume reduction",
         subtype="ANGLE",
         default=MAX_ANGLE,
         min=0.0,
@@ -78,7 +78,7 @@ class AudioParams(HubsComponent):
 
     coneOuterAngle: FloatProperty(
         name="Cone Outer Angle",
-        description="A double value describing the angle, in degrees, of a cone outside of which the volume will be reduced by a constant value, defined by the coneOuterGain attribute.",
+        description="A double value describing the angle, in degrees, of a cone outside of which the volume will be reduced by a constant value, defined by the coneOuterGain attribute",
         subtype="ANGLE",
         default=0.0,
         min=0.0,
@@ -89,7 +89,7 @@ class AudioParams(HubsComponent):
 
     coneOuterGain: FloatProperty(
         name="Cone Outer Gain",
-        description="A double value describing the amount of volume reduction outside the cone defined by the coneOuterAngle attribute.",
+        description="A double value describing the amount of volume reduction outside the cone defined by the coneOuterAngle attribute",
         default=0.0,
         min=0.0,
         soft_min=0.0)

--- a/addons/io_hubs_addon/components/definitions/audio_source.py
+++ b/addons/io_hubs_addon/components/definitions/audio_source.py
@@ -14,10 +14,10 @@ class AudioSource(HubsComponent):
     }
 
     onlyMods: BoolProperty(
-        name="Only Mods", description="Only room moderators should be able to transmit audio from this source.", default=True)
+        name="Only Mods", description="Only room moderators are able to transmit audio from this source", default=True)
 
     muteSelf: BoolProperty(
-        name="Mute Self", description="Do not transmit your own audio to audio targets.", default=True)
+        name="Mute Self", description="Do not transmit your own audio to audio targets", default=True)
 
     debug: BoolProperty(
-        name="Debug", description="Play white noise when no audio source is in the zone.", default=False)
+        name="Debug", description="Play white noise when no audio source is in the zone", default=False)

--- a/addons/io_hubs_addon/components/definitions/audio_target.py
+++ b/addons/io_hubs_addon/components/definitions/audio_target.py
@@ -84,14 +84,14 @@ class AudioTarget(HubsComponent):
 
     srcNode: PointerProperty(
         name="Source",
-        description="Node with a audio-source-zone to pull audio from",
+        description="The object with an audio-source component to pull audio from",
         type=Object,
         poll=filter_on_component
     )
 
     bone: EnumProperty(
         name="Bone",
-        description="Bone",
+        description="The bone with an audio-source component to pull audio from.  If a bone is selected, this will override the object source, otherwise if no bone is selected, the source will be pulled from the object",
         items=get_bones,
         get=get_bone,
         set=set_bone
@@ -140,12 +140,12 @@ class AudioTarget(HubsComponent):
             col = layout.column()
             col.alert = True
             col.label(
-                text=f'The selected source doesn\'t have a {AudioSource.get_display_name()} component', icon='ERROR')
+                text=f'The selected source doesn\'t have an {AudioSource.get_display_name()} component', icon='ERROR')
         elif self.srcNode and self.bone_id != BLANK_ID and not has_bone_component:
             col = layout.column()
             col.alert = True
             col.label(
-                text=f'The selected bone doesn\'t have a {AudioSource.get_display_name()} component', icon='ERROR')
+                text=f'The selected bone doesn\'t have an {AudioSource.get_display_name()} component', icon='ERROR')
 
         layout.prop(data=self, property="minDelay")
         layout.prop(data=self, property="maxDelay")

--- a/addons/io_hubs_addon/components/definitions/billboard.py
+++ b/addons/io_hubs_addon/components/definitions/billboard.py
@@ -14,4 +14,4 @@ class Billboard(HubsComponent):
     }
 
     onlyY: BoolProperty(
-        name="Only Y", description="Rotate only in Y axis", default=False)
+        name="Only Y", description="Rotate only on the Y axis", default=False)

--- a/addons/io_hubs_addon/components/definitions/environment_settings.py
+++ b/addons/io_hubs_addon/components/definitions/environment_settings.py
@@ -5,7 +5,7 @@ from ..hubs_component import HubsComponent
 from ..types import Category, PanelType, NodeType
 
 
-TOME_MAPPING = [("NoToneMapping", "None", "No tone mapping."),
+TOME_MAPPING = [("NoToneMapping", "None", "No tone mapping"),
                 ("LinearToneMapping", "Linear", "Linear tone mapping"),
                 ("ReinhardToneMapping", "ThreeJS 'Reinhard'",
                  "ThreeJS 'Reinhard' tone mapping"),

--- a/addons/io_hubs_addon/components/definitions/frustrum.py
+++ b/addons/io_hubs_addon/components/definitions/frustrum.py
@@ -6,7 +6,7 @@ from ..types import Category, PanelType, NodeType
 class Frustrum(HubsComponent):
     _definition = {
         'name': 'frustrum',
-        'display_name': 'Frustrum',
+        'display_name': 'Frustum',
         'category': Category.OBJECT,
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT],
@@ -14,4 +14,4 @@ class Frustrum(HubsComponent):
     }
 
     culled: BoolProperty(
-        name="Culled", description="Ignore entities outside of the camera frustrum. Frustrum culling can cause problems with some animations", default=True)
+        name="Culled", description="Ignore entities outside of the camera frustum. Frustum culling can cause problems with some animations", default=True)

--- a/addons/io_hubs_addon/components/definitions/image.py
+++ b/addons/io_hubs_addon/components/definitions/image.py
@@ -17,9 +17,9 @@ class Image(HubsComponent):
     }
 
     src: StringProperty(
-        name="Image URL", description="Image URL", default="https://mozilla.org")
+        name="Image URL", description="The web address of the image", default="https://mozilla.org")
 
-    controls: BoolProperty(name="Controls", default=True)
+    controls: BoolProperty(name="Controls", description="When enabled, shows an \"open link\" button when hovering your cursor over it in Hubs that allows you to open the image in a new tab", default=True)
 
     alphaMode: EnumProperty(
         name="Transparency Mode",

--- a/addons/io_hubs_addon/components/definitions/loop_animation.py
+++ b/addons/io_hubs_addon/components/definitions/loop_animation.py
@@ -574,7 +574,7 @@ class LoopAnimation(HubsComponent):
 
     timeScale: FloatProperty(
         name="Time Scale",
-        description="Scale animation playback speed by this factor. Normal playback rate being 1. Negative values will play the animation backwards.",
+        description="Scale animation playback speed by this factor. Normal playback rate being 1. Negative values will play the animation backwards",
         default=1.0
     )
 

--- a/addons/io_hubs_addon/components/definitions/media_frame.py
+++ b/addons/io_hubs_addon/components/definitions/media_frame.py
@@ -60,7 +60,7 @@ class MediaFrame(HubsComponent):
 
     bounds: FloatVectorProperty(
         name="Bounds",
-        description="Bounding box to fit objects into when they are snapped into the media frame.",
+        description="Bounding box to fit objects into when they are snapped into the media frame",
         unit='LENGTH',
         subtype="XYZ",
         default=(1.0, 1.0, 1.0))
@@ -68,17 +68,17 @@ class MediaFrame(HubsComponent):
     mediaType: EnumProperty(
         name="Media Type",
         description="Limit what type of media this frame will capture",
-        items=[("all", "All Media", "Allow any type of media."),
-               ("all-2d", "Only 2D Media", "Allow only Images, Videos, and PDFs."),
-               ("model", "Only 3D Models", "Allow only 3D models."),
-               ("image", "Only Images", "Allow only images."),
-               ("video", "Only Videos", "Allow only videos."),
-               ("pdf", "Only PDFs", "Allow only PDFs.")],
+        items=[("all", "All Media", "Allow any type of media"),
+               ("all-2d", "Only 2D Media", "Allow only Images, Videos, and PDFs"),
+               ("model", "Only 3D Models", "Allow only 3D models"),
+               ("image", "Only Images", "Allow only images"),
+               ("video", "Only Videos", "Allow only videos"),
+               ("pdf", "Only PDFs", "Allow only PDFs")],
         default="all-2d")
 
     snapToCenter: BoolProperty(
         name="Snap To Center",
-        description="Snap the media to the center of the media frame when capturing. If set to false the object will just remain in the place it was dorpped but still be considered \"captured\" by the media frame.",
+        description="Snap the media to the center of the media frame when capturing. If set to false the object will just remain in the place it was dropped but still be considered \"captured\" by the media frame",
         default=True
     )
 

--- a/addons/io_hubs_addon/components/definitions/particle_emitter.py
+++ b/addons/io_hubs_addon/components/definitions/particle_emitter.py
@@ -15,7 +15,7 @@ class ParticleEmitter(HubsComponent):
     }
 
     src: StringProperty(
-        name="Source", description="Source", default="https://mozilla.org")
+        name="Image Source", description="The web address (URL) of the image to use for each particle", default="https://mozilla.org")
 
     startColor: FloatVectorProperty(name="Start Color",
                                     description="Start Color",
@@ -75,7 +75,7 @@ class ParticleEmitter(HubsComponent):
         name="Age Randomness", description="Age Randomness", default=0.0)
 
     lifetime: FloatProperty(
-        name="Lifetime", description="Lifetime  ", unit="TIME", subtype="TIME", default=1.0)
+        name="Lifetime", description="Lifetime", unit="TIME", subtype="TIME", default=1.0)
 
     lifetimeRandomness: FloatProperty(
         name="Lifetime Randomness", description="Lifetime Randomness", default=0.0)

--- a/addons/io_hubs_addon/components/definitions/spawner.py
+++ b/addons/io_hubs_addon/components/definitions/spawner.py
@@ -15,7 +15,7 @@ class Spawner(HubsComponent):
     }
 
     src: StringProperty(
-        name="URL", description="Source image URL", default="https://mozilla.org")
+        name="Model Source", description="The web address (URL) of the glTF to be spawned", default="https://mozilla.org")
 
     applyGravity: BoolProperty(
         name="Apply Gravity", description="Apply gravity to spawned object", default=False)

--- a/addons/io_hubs_addon/components/definitions/spot_light.py
+++ b/addons/io_hubs_addon/components/definitions/spot_light.py
@@ -36,7 +36,7 @@ class SpotLight(HubsComponent):
 
     innerConeAngle: FloatProperty(
         name="Cone Inner Angle",
-        description="A double value describing the angle, in degrees, of a cone inside of which there will be no volume reduction.",
+        description="A double value describing the angle, in degrees, of a cone inside of which there will be no volume reduction",
         subtype="ANGLE",
         default=0.0,
         min=0.0,
@@ -46,7 +46,7 @@ class SpotLight(HubsComponent):
 
     outerConeAngle: FloatProperty(
         name="Cone Outer Angle",
-        description="A double value describing the angle, in degrees, of a cone outside of which the volume will be reduced by a constant value, defined by the coneOuterGain attribute.",
+        description="A double value describing the angle, in degrees, of a cone outside of which the volume will be reduced by a constant value, defined by the coneOuterGain attribute",
         subtype="ANGLE",
         default=pi / 4,
         min=0.0,

--- a/addons/io_hubs_addon/components/definitions/text.py
+++ b/addons/io_hubs_addon/components/definitions/text.py
@@ -15,18 +15,18 @@ class Text(HubsComponent):
 
     value: StringProperty(
         name="Text",
-        description="The string of text to be rendered. Newlines and repeating whitespace characters are honored.",
+        description="The string of text to be rendered. Newlines and repeating whitespace characters are honored",
         default="Hello world!")
 
     fontSize: FloatProperty(
         name="Font Size",
-        description="Font size, in local meters.",
+        description="Font size, in local meters",
         unit='LENGTH',
         default=0.075)
 
     textAlign: EnumProperty(
         name="Alignment",
-        description="The horizontal alignment of each line of text within the overall text bounding box.",
+        description="The horizontal alignment of each line of text within the overall text bounding box",
         items=[("left", "Left", "Text will be aligned to the left"),
                ("right", "Right", "Text will be aligned to the right"),
                ("center", "Center", "Text will be centered"),
@@ -35,24 +35,24 @@ class Text(HubsComponent):
 
     anchorX: EnumProperty(
         name="Anchor X",
-        description="Defines the horizontal position in the text block that should line up with the local origin.",
-        items=[("left", "Left", "Left side of the text will be at the pivot point of this object."),
+        description="Defines the horizontal position in the text block that should line up with the local origin",
+        items=[("left", "Left", "Left side of the text will be at the pivot point of this object"),
                ("center", "Center",
-                "Center of the text will be at the pivot point of this object."),
-               ("right", "Right", "Right side of the text will be at the pivot point of this object.")],
+                "Center of the text will be at the pivot point of this object"),
+               ("right", "Right", "Right side of the text will be at the pivot point of this object")],
         default="center")
 
     anchorY: EnumProperty(
         name="Anchor Y",
-        description="Defines the vertical position in the text block that should line up with the local origin.",
-        items=[("top", "Top", "Top of the text will be at the pivot point of this object."),
+        description="Defines the vertical position in the text block that should line up with the local origin",
+        items=[("top", "Top", "Top of the text will be at the pivot point of this object"),
                ("top-baseline", "Top Baseline",
-                "Top baseline of the text will be at the pivot point of this object."),
+                "Top baseline of the text will be at the pivot point of this object"),
                ("middle", "Middle",
-                "Middle of the text will be at the pivot point of this object."),
+                "Middle of the text will be at the pivot point of this object"),
                ("bottom-baseline", "Bottom Baseline",
-                "Bottom baseline of the text will be at the pivot point of this object."),
-               ("bottom", "Bottom", "Bottom of the text will be at the pivot point of this object.")],
+                "Bottom baseline of the text will be at the pivot point of this object"),
+               ("bottom", "Bottom", "Bottom of the text will be at the pivot point of this object")],
         default="middle")
 
     color: FloatVectorProperty(name="Color",
@@ -63,36 +63,36 @@ class Text(HubsComponent):
 
     letterSpacing: FloatProperty(
         name="Letter Space",
-        description="Sets a uniform adjustment to spacing between letters after kerning is applied, in local meters. Positive numbers increase spacing and negative numbers decrease it.",
+        description="Sets a uniform adjustment to spacing between letters after kerning is applied, in local meters. Positive numbers increase spacing and negative numbers decrease it",
         unit='LENGTH',
         default=0.0)
 
     lineHeight: FloatProperty(
         name="Line Height",
-        description="Sets the height of each line of text. If 0, a reasonable height based on the chosen font's ascender/descender metrics will be used, otherwise it is interpreted as a multiple of the fontSize.",
+        description="Sets the height of each line of text. If 0, a reasonable height based on the chosen font's ascender/descender metrics will be used, otherwise it is interpreted as a multiple of the fontSize",
         default=0.0)
 
     outlineWidth: StringProperty(
         name="Outline Width",
-        description="The width of an outline/halo to be drawn around each text glyph using the outlineColor and outlineOpacity. This can help improve readability when the text is displayed against a background of low or varying contrast.\n\n The width can be specified as either an absolute number in local units, or as a percentage string e.g. \"10%\" which is interpreted as a percentage of the fontSize.",
+        description="The width of an outline/halo to be drawn around each text glyph using the outlineColor and outlineOpacity. This can help improve readability when the text is displayed against a background of low or varying contrast.\n\n The width can be specified as either an absolute number in local units, or as a percentage string e.g. \"10%\" which is interpreted as a percentage of the fontSize",
         default="0")
 
     outlineColor: FloatVectorProperty(name="Outline Color",
-                                      description="The color to use for the text outline when outlineWidth, outlineBlur, and/or outlineOffsetX/Y are set.",
+                                      description="The color to use for the text outline when outlineWidth, outlineBlur, and/or outlineOffsetX/Y are set",
                                       subtype='COLOR',
                                       default=(0.0, 0.0, 0.0, 1.0),
                                       size=4)
 
     outlineBlur: StringProperty(name="Outline Blur",
-                                description="Specifies a blur radius applied to the outer edge of the text's outlineWidth. If the outlineWidth is zero, the blur will be applied at the glyph edge, like CSS's text-shadow blur radius. A blur plus a nonzero outlineWidth can give a solid outline with a fuzzy outer edge.\n\nThe blur radius can be specified as either an absolute number in local meters, or as a percentage string e.g. \"12%\" which is treated as a percentage of the fontSize.",
+                                description="Specifies a blur radius applied to the outer edge of the text's outlineWidth. If the outlineWidth is zero, the blur will be applied at the glyph edge, like CSS's text-shadow blur radius. A blur plus a nonzero outlineWidth can give a solid outline with a fuzzy outer edge.\n\nThe blur radius can be specified as either an absolute number in local meters, or as a percentage string e.g. \"12%\" which is treated as a percentage of the fontSize",
                                 default="0")
 
     outlineOffsetX: StringProperty(name="Outline X Offset",
-                                   description="This defines a horizontal offset of the text outline. Using an offset with outlineWidth: 0 creates a drop-shadow effect like CSS's text-shadow; also see outlineBlur.\n\n The offsets can be specified as either an absolute number in local units, or as a percentage string e.g. \"12%\" which is treated as a percentage of the fontSize.",
+                                   description="This defines a horizontal offset of the text outline. Using an offset with outlineWidth: 0 creates a drop-shadow effect like CSS's text-shadow; also see outlineBlur.\n\n The offsets can be specified as either an absolute number in local units, or as a percentage string e.g. \"12%\" which is treated as a percentage of the fontSize",
                                    default="0")
 
     outlineOffsetY: StringProperty(name="Outline Y Offset",
-                                   description="This defines a vertical offset of the text outline. Using an offset with outlineWidth: 0 creates a drop-shadow effect like CSS's text-shadow; also see outlineBlur.\n\n The offsets can be specified as either an absolute number in local units, or as a percentage string e.g. \"12%\" which is treated as a percentage of the fontSize.",
+                                   description="This defines a vertical offset of the text outline. Using an offset with outlineWidth: 0 creates a drop-shadow effect like CSS's text-shadow; also see outlineBlur.\n\n The offsets can be specified as either an absolute number in local units, or as a percentage string e.g. \"12%\" which is treated as a percentage of the fontSize",
                                    default="0")
 
     outlineOpacity: FloatProperty(
@@ -104,55 +104,55 @@ class Text(HubsComponent):
 
     fillOpacity: FloatProperty(
         name="Fill Opacity",
-        description="Controls the opacity of just the glyph's fill area, separate from any configured strokeOpacity, outlineOpacity, and the material's opacity. A fillOpacity of 0 will make the fill invisible, leaving just the stroke and/or outline.",
+        description="Controls the opacity of just the glyph's fill area, separate from any configured strokeOpacity, outlineOpacity, and the material's opacity. A fillOpacity of 0 will make the fill invisible, leaving just the stroke and/or outline",
         min=0.0,
         max=1.0,
         default=1.0)
 
     strokeWidth: StringProperty(name="Stroke Width",
-                                description="Sets the width of a stroke drawn inside the edge of each text glyph, using the strokeColor and strokeOpacity.\n\n The width can be specified as either an absolute number in local units, or as a percentage string e.g. \"10%\" which is interpreted as a percentage of the fontSize.",
+                                description="Sets the width of a stroke drawn inside the edge of each text glyph, using the strokeColor and strokeOpacity.\n\n The width can be specified as either an absolute number in local units, or as a percentage string e.g. \"10%\" which is interpreted as a percentage of the fontSize",
                                 default="0")
 
     strokeColor: FloatVectorProperty(name="Stroke Color",
-                                     description="The color of the text stroke, when strokeWidth is nonzero.",
+                                     description="The color of the text stroke, when strokeWidth is nonzero",
                                      subtype='COLOR',
                                      default=(0.0, 0.0, 0.0, 1.0),
                                      size=4)
 
     strokeOpacity: FloatProperty(name="Stroke Opacity",
-                                 description="The opacity of the text stroke, when strokeWidth is nonzero.",
+                                 description="The opacity of the text stroke, when strokeWidth is nonzero",
                                  min=0.0,
                                  max=1.0,
                                  default=1.0)
 
     textIndent: FloatProperty(name="Text Indent",
-                              description="An indentation applied to the first character of each hard newline. Behaves like CSS text-indent.",
+                              description="An indentation applied to the first character of each hard newline. Behaves like CSS text-indent",
                               default=0.0)
 
     whiteSpace: EnumProperty(
         name="Wrapping",
-        description="Defines whether text should wrap when a line reaches the maxWidth.",
-        items=[("normal", "Normal", "Allow wrapping according to the 'wrapping mode'."),
-               ("nowrap", "No Wrapping", "Prevent wrapping.")],
+        description="Defines whether text should wrap when a line reaches the maxWidth",
+        items=[("normal", "Normal", "Allow wrapping according to the 'wrapping mode'"),
+               ("nowrap", "No Wrapping", "Prevent wrapping")],
         default="normal")
 
     overflowWrap: EnumProperty(
         name="Wrapping Mode",
-        description="Defines how text wraps if the whiteSpace property is 'normal'.",
-        items=[("normal", "Normal", "Break only at whitespace characters."),
-               ("break-word", "Break Word", "Allow breaking within words.")],
+        description="Defines how text wraps if the whiteSpace property is 'normal'",
+        items=[("normal", "Normal", "Break only at whitespace characters"),
+               ("break-word", "Break Word", "Allow breaking within words")],
         default="normal")
 
     opacity: FloatProperty(
         name="Opacity",
-        description="The opacity of the entire text object.",
+        description="The opacity of the entire text object",
         min=0.0,
         max=1.0,
         default=1.0)
 
     side: EnumProperty(
         name="Display Side",
-        description="Defines how text wraps if the whiteSpace property is 'normal'.",
+        description="Defines how text wraps if the whiteSpace property is 'normal'",
         items=[("front", "Show on front", "Text will be shown on the front (-Y)"),
                ("back", "Show on back", "Text will be shown on the back (+Y)"),
                ("double", "Show on both", "Text will be shown on both sides")],
@@ -160,20 +160,20 @@ class Text(HubsComponent):
 
     maxWidth: FloatProperty(
         name="Max Width",
-        description="The maximum width of the text block, above which text may start wrapping according to the whiteSpace and overflowWrap properties.",
+        description="The maximum width of the text block, above which text may start wrapping according to the whiteSpace and overflowWrap properties",
         unit='LENGTH',
         default=1.0)
 
     curveRadius: FloatProperty(
         name="Curve Radius",
-        description="Defines a cylindrical radius along which the text's plane will be curved. Positive numbers put the cylinder's centerline (oriented vertically) that distance in front of the text, for a concave curvature, while negative numbers put it behind the text for a convex curvature. The centerline will be aligned with the text's local origin; you can use anchorX to offset it.",
+        description="Defines a cylindrical radius along which the text's plane will be curved. Positive numbers put the cylinder's centerline (oriented vertically) that distance in front of the text, for a concave curvature, while negative numbers put it behind the text for a convex curvature. The centerline will be aligned with the text's local origin; you can use anchorX to offset it",
         unit='LENGTH',
         default=0.0)
 
     direction: EnumProperty(
         name="Direction",
-        description="Sets the base direction for the text.",
-        items=[("auto", "Auto", "Use the default text direction defined by the system and font."),
-               ("ltr", "Left to Right", "Order text left to right."),
-               ("rtl", "Right to Left", "Order text right to left.")],
+        description="Sets the base direction for the tex",
+        items=[("auto", "Auto", "Use the default text direction defined by the system and font"),
+               ("ltr", "Left to Right", "Order text left to right"),
+               ("rtl", "Right to Left", "Order text right to left")],
         default="auto")

--- a/addons/io_hubs_addon/components/definitions/uv_scroll.py
+++ b/addons/io_hubs_addon/components/definitions/uv_scroll.py
@@ -35,5 +35,5 @@ class UVScroll(HubsComponent):
         super().draw(context, layout, panel)
         if not has_texture:
             layout.alert = True
-            layout.label(text='This component requires a texture',
+            layout.label(text='This component requires an image texture',
                          icon='ERROR')

--- a/addons/io_hubs_addon/components/definitions/video.py
+++ b/addons/io_hubs_addon/components/definitions/video.py
@@ -17,7 +17,7 @@ class Video(HubsComponent):
     }
 
     src: StringProperty(
-        name="Video URL", description="Video URL", default='https://')
+        name="Video URL", description="The web address of the video", default='https://mozilla.org')
 
     projection: EnumProperty(
         name="Projection",
@@ -30,7 +30,7 @@ class Video(HubsComponent):
                            default=True)
 
     controls: BoolProperty(name="Show controls",
-                           description="Show Controls",
+                           description="When enabled, shows play/pause, skip forward/back, and, if the video contains audio, volume controls when hovering your cursor over it in Hubs",
                            default=True)
 
     loop: BoolProperty(name="Loop",

--- a/addons/io_hubs_addon/components/definitions/video_texture_target.py
+++ b/addons/io_hubs_addon/components/definitions/video_texture_target.py
@@ -81,20 +81,20 @@ class VideoTextureTarget(HubsComponent):
     }
 
     targetBaseColorMap: BoolProperty(
-        name="Override Base Color Map", description="Should the video texture override the base color map?", default=True)
+        name="Override Base Color Map", description="Causes the video texture to be displayed in place of the base color map", default=True)
 
     targetEmissiveMap: BoolProperty(
-        name="Override Emissive Color Map", description="Should the video texture override the emissive map?", default=False)
+        name="Override Emissive Color Map", description="Causes the video texture to be displayed in place of the emissive map", default=False)
 
     srcNode: PointerProperty(
         name="Source",
-        description="Node with a vide-texture-source to pull video from",
+        description="The object with a video-texture-source component to pull video from",
         type=Object,
         poll=filter_on_component)
 
     bone: EnumProperty(
         name="Bone",
-        description="Bone",
+        description="The bone with a video-texture-source component to pull video from.  If a bone is selected, this will override the object source, otherwise if no bone is selected, the source will be pulled from the object",
         items=get_bones,
         get=get_bone,
         set=set_bone

--- a/addons/io_hubs_addon/components/definitions/waypoint.py
+++ b/addons/io_hubs_addon/components/definitions/waypoint.py
@@ -35,7 +35,7 @@ class Waypoint(HubsComponent):
 
     willDisableMotion: BoolProperty(
         name="Disable Motion",
-        description="Avatars will not be able to move while occupying his waypoint",
+        description="Avatars will not be able to move while occupying this waypoint",
         default=False)
 
     willDisableTeleporting: BoolProperty(

--- a/addons/io_hubs_addon/io/gltf_exporter.py
+++ b/addons/io_hubs_addon/io/gltf_exporter.py
@@ -180,7 +180,7 @@ class glTF2ExportUserExtension:
 class HubsComponentsExtensionProperties(bpy.types.PropertyGroup):
     enabled: bpy.props.BoolProperty(
         name="Export Hubs Components",
-        description='Include this extension in the exported glTF file.',
+        description='Include this extension in the exported glTF file',
         default=True
     )
     version: IntVectorProperty(size=3)

--- a/addons/io_hubs_addon/preferences.py
+++ b/addons/io_hubs_addon/preferences.py
@@ -23,7 +23,7 @@ class HubsPreferences(AddonPreferences):
 
     tmp_path: StringProperty(
         name="Temporary files path",
-        description="Path where temporary files will be stored.",
+        description="Path where temporary files will be stored",
         subtype="DIR_PATH",
         default="//generated_cubemaps/"
     )


### PR DESCRIPTION
Fixed typos and grammar errors.
Added the full (mozilla.org) default URL to the video component (it was just https://). Improved the descriptions/tooltips to better document what the things do. Removed the trailing periods from descriptions/tooltips as Blender provides them for us and will cause duplicates if we provide them too. Periods aren't provided for labels, so those have been left.