### PR TITLE
Fix #111

### DIFF
--- a/addons/io_hubs_addon/components/definitions/reflection_probe.py
+++ b/addons/io_hubs_addon/components/definitions/reflection_probe.py
@@ -196,9 +196,15 @@ class BakeProbeOperator(bpy.types.Operator):
                     img = bpy.data.images.get(image_name)
                     img_path = "%s/%s.hdr" % (get_addon_pref(context).tmp_path,
                                               probe.name)
-                    if not img:
+                    if not img or img.filepath != img_path:
                         img = bpy.data.images.load(filepath=img_path)
                         img.name = image_name
+
+                        for window in context.window_manager.windows:
+                            for area in window.screen.areas:
+                                if area.type == 'IMAGE_EDITOR':
+                                    if area.spaces.active.image == probe.hubs_component_reflection_probe['envMapTexture']:
+                                        area.spaces.active.image = img
                     else:
                         img.reload()
                     self.report(


### PR DESCRIPTION
Fix baking reflection probes after changing the tmp_path by adding an additional check to see if the file path of the new bake is different from the file path of the current bake and update the image for any image editors that are currently displaying it (this mimics the behavior of reloading the image when the tmp_path hasn't been changed).