### PR TITLE
Fix tests for Blender 3.2.0

### DIFF
--- a/tests/test/test_export.js
+++ b/tests/test/test_export.js
@@ -105,10 +105,10 @@ describe('Exporter', function () {
         assert.strictEqual(asset.extensionsUsed.includes('MOZ_hubs_components'), true);
         assert.strictEqual(utils.checkExtensionAdded(asset, 'MOZ_hubs_components'), true);
 
-        const camera = asset.nodes[1];
+        const { node: camera, index: cameraIndex } = utils.nodeWithName(asset, "Camera");
         assert.strictEqual(utils.checkExtensionAdded(camera, 'MOZ_hubs_components'), true);
 
-        const material = asset.materials[0];
+        const { node: material } = utils.materialWithName(asset, "Material.001");
         assert.strictEqual(utils.checkExtensionAdded(material, 'MOZ_hubs_components'), true);
 
         const videoTextureSourceExt = camera.extensions['MOZ_hubs_components'];
@@ -129,7 +129,7 @@ describe('Exporter', function () {
             "targetEmissiveMap": true,
             "srcNode": {
               "__mhc_link_type": "node",
-              "index": 1
+              "index": cameraIndex
             }
           }
         });

--- a/tests/test/utils.js
+++ b/tests/test/utils.js
@@ -71,10 +71,30 @@ function checkExtensionAdded(asset, etxName) {
   return Object.prototype.hasOwnProperty.call(asset.extensions, etxName);
 }
 
+function nodeWithName(gltf, name) {
+  const node = gltf.nodes.filter(node => { return node.name === name; }).pop();
+  const index = gltf.nodes.indexOf(node);
+  return {
+    node,
+    index
+  };
+}
+
+function materialWithName(gltf, name) {
+  const node = gltf.materials.filter(node => { return node.name === name; }).pop();
+  const index = gltf.nodes.indexOf(node);
+  return {
+    node,
+    index
+  };
+}
+
 exports.utils = {
-  UUID_REGEX: UUID_REGEX,
-  blenderFileToGltf: blenderFileToGltf,
-  blenderRoundtripGltf: blenderRoundtripGltf,
-  validateGltf: validateGltf,
-  checkExtensionAdded: checkExtensionAdded
+  UUID_REGEX,
+  blenderFileToGltf,
+  blenderRoundtripGltf,
+  validateGltf,
+  checkExtensionAdded,
+  nodeWithName,
+  materialWithName
 };


### PR DESCRIPTION
The order nodes are processed has changed after https://github.com/MozillaReality/hubs-blender-exporter/pull/107

This PR fixes the broken tests.