### PR TITLE
Change overrideAudioSettings to default to True.

### DIFF
--- a/addons/io_hubs_addon/components/definitions/audio_params.py
+++ b/addons/io_hubs_addon/components/definitions/audio_params.py
@@ -22,7 +22,7 @@ class AudioParams(HubsComponent):
     overrideAudioSettings: BoolProperty(
         name="Override Audio Settings",
         description="Override Audio Settings",
-        default=False)
+        default=True)
 
     audioType: EnumProperty(
         name="Audio Type",


### PR DESCRIPTION
Having overrideAudioSettings default to false broke old files because previously the audio parameters were always applied.

This also brings up the question of how we want overrides to act in regard to the different components, e.g. audio zones will always need to override the audio settings, while videos will probably only override the audio settings occasionally.