### PR TITLE
Update version with the first add-on version items

### DIFF
--- a/addons/io_hubs_addon/components/handlers.py
+++ b/addons/io_hubs_addon/components/handlers.py
@@ -14,7 +14,7 @@ def migrate_components(dummy):
 @persistent
 def version_update(dummy):
     from .. import (bl_info)
-    bpy.context.scene.HubsComponentsExtensionProperties.version = bl_info['version']
+    bpy.context.scene.HubsComponentsExtensionProperties.version = bl_info['version'][0:3]
 
 
 def register():


### PR DESCRIPTION
After the addition of the fourth add-on version tag the version update has broken in local as we expect a tuple of 3 and now we have 4. We use the "dev_build" string for CI substitution and we don't really need to compare against the build number so I think it's fine if we just use the first three tuple numbers.

This only affects local development.