### PR TITLE
Include File Name in Reflection Probes Baked Images.

### DIFF
--- a/addons/io_hubs_addon/components/definitions/reflection_probe.py
+++ b/addons/io_hubs_addon/components/definitions/reflection_probe.py
@@ -99,9 +99,9 @@ class ReflectionProbeSceneProps(PropertyGroup):
                                   default='256x128', options={'HIDDEN'})
 
     use_compositor: BoolProperty(name="Use Compositor",
-        description="Controls whether the baked images will be processed by the compositor after baking",
-        default=False
-    )
+                                 description="Controls whether the baked images will be processed by the compositor after baking",
+                                 default=False
+                                 )
 
 
 class BakeProbeOperator(bpy.types.Operator):
@@ -252,7 +252,7 @@ class BakeProbeOperator(bpy.types.Operator):
 
     def restore_render_props(self):
         for prop in self.saved_props:
-           rsetattr(bpy.context, prop, self.saved_props[prop])
+            rsetattr(bpy.context, prop, self.saved_props[prop])
 
     def render_probe(self, context):
         probe = self.probes[self.probe_index]
@@ -298,6 +298,7 @@ class BakeProbeOperator(bpy.types.Operator):
 
         self.report({'INFO'}, 'Baking probe %s' % probe.name)
         bpy.ops.render.render("INVOKE_DEFAULT", write_still=True)
+
 
 class ReflectionProbe(HubsComponent):
     _definition = {
@@ -364,7 +365,8 @@ class ReflectionProbe(HubsComponent):
                           icon='ERROR')
 
             row = col.row()
-            row.prop(context.scene.hubs_scene_reflection_probe_properties, "use_compositor")
+            row.prop(
+                context.scene.hubs_scene_reflection_probe_properties, "use_compositor")
 
             global bake_mode
 

--- a/addons/io_hubs_addon/components/definitions/reflection_probe.py
+++ b/addons/io_hubs_addon/components/definitions/reflection_probe.py
@@ -75,6 +75,14 @@ def get_probes():
     return probes
 
 
+def get_probe_image_path(context, probe):
+    tmp_path = get_addon_pref(context).tmp_path
+    blendfile_name = bpy.path.display_name_from_filepath(bpy.data.filepath)
+    if not blendfile_name:
+        blendfile_name = "untitled"
+    return f"{tmp_path}/{blendfile_name}-{probe.name}.hdr"
+
+
 class ReflectionProbeSceneProps(PropertyGroup):
     resolution: EnumProperty(name='Resolution',
                              description='Reflection Probe Selected Environment Map Resolution',
@@ -200,8 +208,7 @@ class BakeProbeOperator(bpy.types.Operator):
                 for probe in self.probes:
                     image_name = "generated_cubemap-%s" % probe.name
                     img = bpy.data.images.get(image_name)
-                    img_path = "%s/%s.hdr" % (get_addon_pref(context).tmp_path,
-                                              probe.name)
+                    img_path = get_probe_image_path(context, probe)
                     if not img or img.filepath != img_path:
                         img = bpy.data.images.load(filepath=img_path)
                         img.name = image_name
@@ -267,7 +274,7 @@ class BakeProbeOperator(bpy.types.Operator):
 
         resolution = context.scene.hubs_scene_reflection_probe_properties.resolution
         (x, y) = [int(i) for i in resolution.split('x')]
-        output_path = "%s/%s.hdr" % (get_addon_pref(context).tmp_path, probe.name)
+        output_path = get_probe_image_path(context, probe)
         use_compositor = context.scene.hubs_scene_reflection_probe_properties.use_compositor
 
         overrides = [


### PR DESCRIPTION
This PR includes the name of the blend file in the reflection probes' baked image file names.  This reduces name collisions when using the default relative path for
reflection probe bakes and there are multiple blend files in the same folder or when using a single absolute path for all bakes.

If the blend file hasn't been saved yet, "untitled" is used as the blend file name.

Name conflicts are still possible if blend files in different folders are named the same.

I considered using uuids to prevent name collisions, however these aren't human friendly and also either prevent overwriting previous images for the same probe or would be difficult to manage if a uuid was assigned to a probe and all of its bakes used that as the file name (it would face similar problems to what the networked component did).