### PR TITLE
Move Untitled Reflection Probe Bakes to the tmp_path Directory on Save.

### DIFF
--- a/addons/io_hubs_addon/components/definitions/reflection_probe.py
+++ b/addons/io_hubs_addon/components/definitions/reflection_probe.py
@@ -246,6 +246,9 @@ class BakeProbeOperator(bpy.types.Operator):
         self.post_render_wait = 500
         self.probe_index = len(self.probes) - 1
 
+        global stored_preferences_is_dirty
+        stored_preferences_is_dirty = bpy.context.preferences.is_dirty
+
         probe_baking = True
 
         return {"RUNNING_MODAL"}
@@ -325,7 +328,6 @@ class BakeProbeOperator(bpy.types.Operator):
         stored_preferences_is_dirty = None
 
     def render_probe(self, context):
-        global stored_preferences_is_dirty
         probe = self.probes[self.probe_index]
 
         self.camera_data.type = "PANO"
@@ -362,7 +364,6 @@ class BakeProbeOperator(bpy.types.Operator):
             ("scene.use_nodes", use_compositor)
         ]
 
-        stored_preferences_is_dirty = bpy.context.preferences.is_dirty
         for (prop, value) in overrides:
             if prop not in self.saved_props:
                 self.saved_props[prop] = rgetattr(bpy.context, prop)

--- a/addons/io_hubs_addon/components/definitions/reflection_probe.py
+++ b/addons/io_hubs_addon/components/definitions/reflection_probe.py
@@ -75,6 +75,14 @@ def get_probes():
     return probes
 
 
+def get_probe_image_path(context, probe):
+    tmp_path = get_addon_pref(context).tmp_path
+    blendfile_name = bpy.path.display_name_from_filepath(bpy.data.filepath)
+    if not blendfile_name:
+        blendfile_name = "untitled"
+    return f"{tmp_path}/{blendfile_name}-{probe.name}.hdr"
+
+
 class ReflectionProbeSceneProps(PropertyGroup):
     resolution: EnumProperty(name='Resolution',
                              description='Reflection Probe Selected Environment Map Resolution',
@@ -200,8 +208,7 @@ class BakeProbeOperator(bpy.types.Operator):
                 for probe in self.probes:
                     image_name = "generated_cubemap-%s" % probe.name
                     img = bpy.data.images.get(image_name)
-                    img_path = "%s/%s.hdr" % (get_addon_pref(context).tmp_path,
-                                              probe.name)
+                    img_path = get_probe_image_path(context, probe)
                     if not img or img.filepath != img_path:
                         img = bpy.data.images.load(filepath=img_path)
                         img.name = image_name
@@ -267,7 +274,7 @@ class BakeProbeOperator(bpy.types.Operator):
 
         resolution = context.scene.hubs_scene_reflection_probe_properties.resolution
         (x, y) = [int(i) for i in resolution.split('x')]
-        output_path = "%s/%s.hdr" % (get_addon_pref(context).tmp_path, probe.name)
+        output_path = get_probe_image_path(context, probe)
         use_compositor = context.scene.hubs_scene_reflection_probe_properties.use_compositor
 
         overrides = [

--- a/addons/io_hubs_addon/components/definitions/reflection_probe.py
+++ b/addons/io_hubs_addon/components/definitions/reflection_probe.py
@@ -40,7 +40,7 @@ save_handler = {
     'transfer_probe_images': False,
     'stored_save_version': None,
     'final_save': False
-    }
+}
 
 
 def get_resolutions(self, context):
@@ -102,7 +102,7 @@ def save_pre(dummy):
         return
 
     if not bpy.data.filepath:
-       save_handler['transfer_probe_images'] = True
+        save_handler['transfer_probe_images'] = True
 
 
 @ persistent
@@ -120,24 +120,29 @@ def save_post(dummy):
 
     if save_handler['transfer_probe_images'] and bpy.data.filepath:
         ref_probe_path = get_addon_pref(bpy.context).ref_probe_path
-        absolute_ref_probe_path = os.path.realpath(bpy.path.abspath(ref_probe_path))
+        absolute_ref_probe_path = os.path.realpath(
+            bpy.path.abspath(ref_probe_path))
         for probe in get_probes(all_objects=True):
             envMapTexture = probe.hubs_component_reflection_probe.envMapTexture
             current_probe_image_path = envMapTexture.filepath
             current_image_absolute_path = os.path.realpath(
                 bpy.path.abspath(current_probe_image_path))
-            current_image_directory = os.path.dirname(current_image_absolute_path)
+            current_image_directory = os.path.dirname(
+                current_image_absolute_path)
             if pathlib.Path(current_image_directory) == pathlib.Path(bpy.app.tempdir):
                 new_image_path = compose_probe_image_path(bpy.context, probe)
                 new_image_absolute_path = os.path.realpath(
                     bpy.path.abspath(new_image_path))
                 try:
-                    pathlib.Path(absolute_ref_probe_path).mkdir(parents=True, exist_ok=True)
-                    shutil.move(current_image_absolute_path, new_image_absolute_path)
+                    pathlib.Path(absolute_ref_probe_path).mkdir(
+                        parents=True, exist_ok=True)
+                    shutil.move(current_image_absolute_path,
+                                new_image_absolute_path)
                     envMapTexture.filepath = new_image_path
 
                 except Exception as e:
-                    print(f"Error: Could not transfer reflection probe environment map \'{current_image_absolute_path}\' to \'{new_image_absolute_path}\'")
+                    print(
+                        f"Error: Could not transfer reflection probe environment map \'{current_image_absolute_path}\' to \'{new_image_absolute_path}\'")
                     print(e)
 
         save_handler['transfer_probe_images'] = False
@@ -166,9 +171,9 @@ class ReflectionProbeSceneProps(PropertyGroup):
                                   default='256x128', options={'HIDDEN'})
 
     use_compositor: BoolProperty(name="Use Compositor",
-        description="Controls whether the baked images will be processed by the compositor after baking",
-        default=False
-    )
+                                 description="Controls whether the baked images will be processed by the compositor after baking",
+                                 default=False
+                                 )
 
 
 class BakeProbeOperator(bpy.types.Operator):
@@ -323,7 +328,7 @@ class BakeProbeOperator(bpy.types.Operator):
     def restore_render_props(self):
         global stored_preferences_is_dirty
         for prop in self.saved_props:
-           rsetattr(bpy.context, prop, self.saved_props[prop])
+            rsetattr(bpy.context, prop, self.saved_props[prop])
         bpy.context.preferences.is_dirty = stored_preferences_is_dirty
         stored_preferences_is_dirty = None
 
@@ -371,6 +376,7 @@ class BakeProbeOperator(bpy.types.Operator):
 
         self.report({'INFO'}, 'Baking probe %s' % probe.name)
         bpy.ops.render.render("INVOKE_DEFAULT", write_still=True)
+
 
 class ReflectionProbe(HubsComponent):
     _definition = {
@@ -437,7 +443,8 @@ class ReflectionProbe(HubsComponent):
                           icon='ERROR')
 
             row = col.row()
-            row.prop(context.scene.hubs_scene_reflection_probe_properties, "use_compositor")
+            row.prop(
+                context.scene.hubs_scene_reflection_probe_properties, "use_compositor")
 
             global bake_mode
 

--- a/addons/io_hubs_addon/components/definitions/reflection_probe.py
+++ b/addons/io_hubs_addon/components/definitions/reflection_probe.py
@@ -87,12 +87,12 @@ def get_probes(all_objects=False):
 
 
 def compose_probe_image_path(context, probe):
-    tmp_path = get_addon_pref(context).tmp_path
+    ref_probe_path = get_addon_pref(context).ref_probe_path
     blendfile_name = bpy.path.display_name_from_filepath(bpy.data.filepath)
     if not blendfile_name:
         blendfile_name = "untitled"
-        tmp_path = bpy.app.tempdir
-    return f"{tmp_path}/{blendfile_name}-{probe.name}.hdr"
+        ref_probe_path = bpy.app.tempdir
+    return f"{ref_probe_path}/{blendfile_name}-{probe.name}.hdr"
 
 
 @ persistent
@@ -119,8 +119,8 @@ def save_post(dummy):
         return
 
     if save_handler['transfer_probe_images'] and bpy.data.filepath:
-        tmp_path = get_addon_pref(bpy.context).tmp_path
-        absolute_tmp_path = os.path.realpath(bpy.path.abspath(tmp_path))
+        ref_probe_path = get_addon_pref(bpy.context).ref_probe_path
+        absolute_ref_probe_path = os.path.realpath(bpy.path.abspath(ref_probe_path))
         for probe in get_probes(all_objects=True):
             envMapTexture = probe.hubs_component_reflection_probe.envMapTexture
             current_probe_image_path = envMapTexture.filepath
@@ -132,7 +132,7 @@ def save_post(dummy):
                 new_image_absolute_path = os.path.realpath(
                     bpy.path.abspath(new_image_path))
                 try:
-                    pathlib.Path(absolute_tmp_path).mkdir(parents=True, exist_ok=True)
+                    pathlib.Path(absolute_ref_probe_path).mkdir(parents=True, exist_ok=True)
                     shutil.move(current_image_absolute_path, new_image_absolute_path)
                     envMapTexture.filepath = new_image_path
 

--- a/addons/io_hubs_addon/preferences.py
+++ b/addons/io_hubs_addon/preferences.py
@@ -34,6 +34,12 @@ class HubsPreferences(AddonPreferences):
 
         box.row().prop(self, "row_length")
         box.row().prop(self, "tmp_path")
+        if not bpy.data.filepath:
+            tmp_path_notice = box.column()
+            tmp_path_notice.scale_y = 0.7
+            tmp_path_notice.alert = True
+            tmp_path_notice.label(text=f"New file detected, redirecting output directory to: {bpy.app.tempdir}", icon='ERROR')
+            tmp_path_notice.label(text=f"The contents will be transferred to the main directory when the blend file is saved", icon='BLANK1')
 
 
 def register():

--- a/addons/io_hubs_addon/preferences.py
+++ b/addons/io_hubs_addon/preferences.py
@@ -38,8 +38,10 @@ class HubsPreferences(AddonPreferences):
             ref_probe_path_notice = box.column()
             ref_probe_path_notice.scale_y = 0.7
             ref_probe_path_notice.alert = True
-            ref_probe_path_notice.label(text=f"New file detected, redirecting output directory to: {bpy.app.tempdir}", icon='ERROR')
-            ref_probe_path_notice.label(text=f"The contents will be transferred to the main directory when the blend file is saved", icon='BLANK1')
+            ref_probe_path_notice.label(
+                text=f"New file detected, redirecting output directory to: {bpy.app.tempdir}", icon='ERROR')
+            ref_probe_path_notice.label(
+                text=f"The contents will be transferred to the main directory when the blend file is saved", icon='BLANK1')
 
 
 def register():

--- a/addons/io_hubs_addon/preferences.py
+++ b/addons/io_hubs_addon/preferences.py
@@ -21,9 +21,9 @@ class HubsPreferences(AddonPreferences):
         min=0,
     )
 
-    tmp_path: StringProperty(
-        name="Temporary files path",
-        description="Path where temporary files will be stored",
+    ref_probe_path: StringProperty(
+        name="Reflection Probe Output Directory",
+        description="Path where Reflection Probe bakes will be stored",
         subtype="DIR_PATH",
         default="//generated_cubemaps/"
     )
@@ -33,13 +33,13 @@ class HubsPreferences(AddonPreferences):
         box = layout.box()
 
         box.row().prop(self, "row_length")
-        box.row().prop(self, "tmp_path")
+        box.row().prop(self, "ref_probe_path")
         if not bpy.data.filepath:
-            tmp_path_notice = box.column()
-            tmp_path_notice.scale_y = 0.7
-            tmp_path_notice.alert = True
-            tmp_path_notice.label(text=f"New file detected, redirecting output directory to: {bpy.app.tempdir}", icon='ERROR')
-            tmp_path_notice.label(text=f"The contents will be transferred to the main directory when the blend file is saved", icon='BLANK1')
+            ref_probe_path_notice = box.column()
+            ref_probe_path_notice.scale_y = 0.7
+            ref_probe_path_notice.alert = True
+            ref_probe_path_notice.label(text=f"New file detected, redirecting output directory to: {bpy.app.tempdir}", icon='ERROR')
+            ref_probe_path_notice.label(text=f"The contents will be transferred to the main directory when the blend file is saved", icon='BLANK1')
 
 
 def register():


### PR DESCRIPTION
This PR builds on the file name inclusion PR and redirects the reflection probe bakes from untitled files to Blender's session temp directory (a message is displayed to the user underneath the tmp_path field in the preferences to inform them of this) to avoid any permission errors and uncertainty from relative paths.  On saving the blend file the reflection probe bakes are transferred to the directory specified in tmp_path.  However because of limitations in Blender's save handlers, we end up having to save the blend file twice in order to save the new paths, and Blender's backup saves have to be disabled during the second save to prevent messing them up.  Also, saving a copy of the blend file won't trigger a transfer or rename, and the copy will continue to look for the files in Blender's session temp directory.

Unfortunately, this can't be taken any further to prevent overwriting bakes of the previously saved blend file because there is no way to get the new file path/name when saving a copy, and because of how we need to update the blend file to point to the new paths, saving a copy will trigger a save of the current blend file, thus overwriting your last save.  While I don't use Save Copy often, I think it's too dangerous to continue any further down this road.