### PR TITLE
Store Reflection Probe Bakes in Blend Files.

### DIFF
--- a/addons/io_hubs_addon/components/definitions/reflection_probe.py
+++ b/addons/io_hubs_addon/components/definitions/reflection_probe.py
@@ -209,6 +209,16 @@ class BakeProbeOperator(bpy.types.Operator):
                     # Store the old image's full name in case of name juggling.
                     old_img_name_full = old_img.name_full if old_img else ""
 
+                    conflicting_img = None
+                    for img in bpy.data.images:
+                        if img.name == image_name and not img.library:
+                            conflicting_img = img
+                            break
+
+                    if conflicting_img and conflicting_img != old_img:
+                        # Rename the conflicting image to help avoid problems caused by Blender's name juggling and allow name juggled images to be more easily found.
+                        conflicting_img.name = f"{conflicting_img.name}-old"
+
                     img_path = get_probe_image_path(probe)
                     img = bpy.data.images.load(filepath=img_path)
                     img.name = image_name

--- a/addons/io_hubs_addon/components/definitions/reflection_probe.py
+++ b/addons/io_hubs_addon/components/definitions/reflection_probe.py
@@ -96,11 +96,13 @@ def update_image_editors(old_img, img):
 
 
 def import_menu_draw(self, context):
-    self.layout.operator("image.hubs_import_reflection_probe_envmaps", text="Import Reflection Probe EnvMaps")
+    self.layout.operator("image.hubs_import_reflection_probe_envmaps",
+                         text="Import Reflection Probe EnvMaps")
 
 
 def export_menu_draw(self, context):
-    self.layout.operator("image.hubs_export_reflection_probe_envmaps", text="Export Reflection Probe EnvMaps")
+    self.layout.operator("image.hubs_export_reflection_probe_envmaps",
+                         text="Export Reflection Probe EnvMaps")
 
 
 class ReflectionProbeSceneProps(PropertyGroup):
@@ -119,9 +121,9 @@ class ReflectionProbeSceneProps(PropertyGroup):
                                   default='256x128', options={'HIDDEN'})
 
     use_compositor: BoolProperty(name="Use Compositor",
-        description="Controls whether the baked images will be processed by the compositor after baking",
-        default=False
-    )
+                                 description="Controls whether the baked images will be processed by the compositor after baking",
+                                 default=False
+                                 )
 
 
 class BakeProbeOperator(Operator):
@@ -291,7 +293,6 @@ class BakeProbeOperator(Operator):
                         else:
                             update_image_editors(old_img, img)
 
-
                     probe_component['envMapTexture'] = img
 
                     # Pack image and update filepaths so that it displays/unpacks nicely for the user.
@@ -330,7 +331,7 @@ class BakeProbeOperator(Operator):
 
     def restore_render_props(self):
         for prop in self.saved_props:
-           rsetattr(bpy.context, prop, self.saved_props[prop])
+            rsetattr(bpy.context, prop, self.saved_props[prop])
         bpy.context.preferences.is_dirty = self.preferences_is_dirty_state
         self.preferences_is_dirty_state = None
 
@@ -379,6 +380,7 @@ class BakeProbeOperator(Operator):
         self.report({'INFO'}, 'Baking probe %s' % probe.name)
         self.probe_is_setup = True
 
+
 class OpenReflectionProbeEnvMap(Operator):
     bl_idname = "image.hubs_open_reflection_probe_envmap"
     bl_label = "Open EnvMap"
@@ -390,7 +392,8 @@ class OpenReflectionProbeEnvMap(Operator):
     filter_folder: BoolProperty(default=True, options={"HIDDEN"})
     filter_image: BoolProperty(default=True, options={"HIDDEN"})
 
-    relative_path: BoolProperty(name="Relative Path", description="Select the file relative to the blend file", default=True)
+    relative_path: BoolProperty(
+        name="Relative Path", description="Select the file relative to the blend file", default=True)
 
     def draw(self, context):
         layout = self.layout
@@ -408,12 +411,14 @@ class OpenReflectionProbeEnvMap(Operator):
 
         # Load/Reload the first image and assign it to the reflection probe, then load the rest of the images if they're not already loaded.  This mimics Blender's default open files behavior.
         primary_filepath = os.path.join(dirname, self.files[0].name)
-        primary_img = bpy.data.images.load(filepath=primary_filepath, check_existing=True)
+        primary_img = bpy.data.images.load(
+            filepath=primary_filepath, check_existing=True)
         primary_img.reload()
         probe_component['envMapTexture'] = primary_img
 
         for f in self.files[1:]:
-            img = bpy.data.images.load(filepath=os.path.join(dirname, f.name), check_existing=True)
+            img = bpy.data.images.load(filepath=os.path.join(
+                dirname, f.name), check_existing=True)
 
         update_image_editors(old_img, primary_img)
         redraw_component_ui(context)
@@ -445,8 +450,10 @@ class ImportReflectionProbeEnvMaps(Operator):
     filter_folder: BoolProperty(default=True, options={"HIDDEN"})
     filter_image: BoolProperty(default=True, options={"HIDDEN"})
 
-    relative_path: BoolProperty(name="Relative Path", description="Select the file relative to the blend file", default=True)
-    overwrite_images: BoolProperty(name="Overwrite Probe Images", description="Overwrite/Remove the current images of the reflection probes being imported to", default=False)
+    relative_path: BoolProperty(
+        name="Relative Path", description="Select the file relative to the blend file", default=True)
+    overwrite_images: BoolProperty(
+        name="Overwrite Probe Images", description="Overwrite/Remove the current images of the reflection probes being imported to", default=False)
 
     def draw(self, context):
         layout = self.layout
@@ -466,7 +473,8 @@ class ImportReflectionProbeEnvMaps(Operator):
         dirname = os.path.dirname(self.filepath)
 
         if not self.files[0].name:
-            self.report({'INFO'}, "Import EnvMaps cancelled.  No images selected.")
+            self.report(
+                {'INFO'}, "Import EnvMaps cancelled.  No images selected.")
             return {'CANCELLED'}
 
         num_imported = 0
@@ -479,7 +487,8 @@ class ImportReflectionProbeEnvMaps(Operator):
                     probe_component = probe.hubs_component_reflection_probe
                     old_img = probe_component['envMapTexture']
 
-                    img = bpy.data.images.load(filepath=os.path.join(dirname, f.name))
+                    img = bpy.data.images.load(
+                        filepath=os.path.join(dirname, f.name))
                     probe_component['envMapTexture'] = img
 
                     if old_img:
@@ -497,12 +506,13 @@ class ImportReflectionProbeEnvMaps(Operator):
 
                     imported_file = True
                     num_imported += 1
-                    self.report({'INFO'}, f"Imported {f.name} to probe {probe.name}")
+                    self.report(
+                        {'INFO'}, f"Imported {f.name} to probe {probe.name}")
 
             if not imported_file:
                 num_failed += 1
-                self.report({'WARNING'}, f"Warning: Couldn't import {f.name}.  The corresponding probe either doesn't exist or is locked/linked.")
-
+                self.report(
+                    {'WARNING'}, f"Warning: Couldn't import {f.name}.  The corresponding probe either doesn't exist or is locked/linked.")
 
         if num_failed:
             final_report_message = f"Warning: {num_failed} environment maps failed to import. {num_imported} environment maps imported to probes"
@@ -528,24 +538,26 @@ class ExportReflectionProbeEnvMaps(Operator):
     filter_folder: BoolProperty(default=True, options={"HIDDEN"})
     filter_image: BoolProperty(default=True, options={"HIDDEN"})
 
-
     batch_type: EnumProperty(
         name="Batch Type",
         description="Choose which probes to export",
         items=(
-            ('ALL', "All Probes", "Export the environment maps from all probes in the current view layer"),
-            ('SELECTED', "Selected Probes", "Export the environment maps from the selected probes"),
+            ('ALL', "All Probes",
+             "Export the environment maps from all probes in the current view layer"),
+            ('SELECTED', "Selected Probes",
+             "Export the environment maps from the selected probes"),
         ),
         default='ALL',
     )
 
-    include_locked: BoolProperty(name="Include Locked", description="Include environment maps from locked probes", default=False)
+    include_locked: BoolProperty(
+        name="Include Locked", description="Include environment maps from locked probes", default=False)
 
     naming_scheme: StringProperty(
         name="Output Naming Scheme",
         description="How exported files will be named",
         default="<Probe Name> - EnvMap.hdr"
-        )
+    )
 
     def draw(self, context):
         layout = self.layout
@@ -559,12 +571,14 @@ class ExportReflectionProbeEnvMaps(Operator):
 
     def execute(self, context):
         if self.batch_type == 'SELECTED':
-            probes = [ob for ob in get_probes(include_locked=self.include_locked) if ob in context.selected_objects]
+            probes = [ob for ob in get_probes(
+                include_locked=self.include_locked) if ob in context.selected_objects]
         else:
             probes = get_probes(include_locked=self.include_locked)
 
         if not probes:
-            self.report({'WARNING'}, "Export EnvMaps cancelled.  No local probes matching the criteria were found.")
+            self.report(
+                {'WARNING'}, "Export EnvMaps cancelled.  No local probes matching the criteria were found.")
             return {'CANCELLED'}
 
         num_exported = 0
@@ -576,11 +590,14 @@ class ExportReflectionProbeEnvMaps(Operator):
                 envMapTexture.filepath_raw = export_path
                 envMapTexture.save()
                 envMapTexture.filepath_raw = orig_filepath_raw
-                self.report({'INFO'}, f"Exported environment map for probe {probe.name}")
+                self.report(
+                    {'INFO'}, f"Exported environment map for probe {probe.name}")
                 num_exported += 1
             else:
-                self.report({'WARNING'}, f"Reflection probe {probe.name} doesn't have an environment map to export")
-        self.report({'INFO'}, f"Exported {num_exported} environment maps to {self.directory}")
+                self.report(
+                    {'WARNING'}, f"Reflection probe {probe.name} doesn't have an environment map to export")
+        self.report(
+            {'INFO'}, f"Exported {num_exported} environment maps to {self.directory}")
         return {'FINISHED'}
 
     def invoke(self, context, event):
@@ -622,6 +639,7 @@ class SelectMismatchedReflectionProbes(Operator):
 
     def invoke(self, context, event):
         probes = get_probes(include_locked=True, include_linked=True)
+
         def draw(self, context):
             layout = self.layout
             layout.label(text="Select Mismatched Probes")
@@ -638,20 +656,25 @@ class SelectMismatchedReflectionProbes(Operator):
                         mismatched_probe_indexes.append(i)
                         mismatched_probes.append(probe)
 
-            is_selected = (context.selected_objects == mismatched_probes and not context.active_object)
+            is_selected = (context.selected_objects ==
+                           mismatched_probes and not context.active_object)
             icon = 'RADIOBUT_ON' if is_selected else 'RADIOBUT_OFF'
-            op = layout.operator(SelectMismatchedReflectionProbes.bl_idname, text="Select All", icon=icon)
+            op = layout.operator(
+                SelectMismatchedReflectionProbes.bl_idname, text="Select All", icon=icon)
             op.select_all = True
-            op.mismatched_probe_indexes = ','.join(map(str, mismatched_probe_indexes))
+            op.mismatched_probe_indexes = ','.join(
+                map(str, mismatched_probe_indexes))
 
             layout.separator()
 
             for probe in mismatched_probes:
-                is_selected = (probe == context.active_object and probe in context.selected_objects and len(context.selected_objects) == 1)
+                is_selected = (probe == context.active_object and probe in context.selected_objects and len(
+                    context.selected_objects) == 1)
                 icon = 'RADIOBUT_ON' if is_selected else 'RADIOBUT_OFF'
                 row = layout.row()
                 row.context_pointer_set("probe", probe)
-                op = row.operator(SelectMismatchedReflectionProbes.bl_idname, text=probe.name_full, icon=icon)
+                op = row.operator(
+                    SelectMismatchedReflectionProbes.bl_idname, text=probe.name_full, icon=icon)
                 op.select_all = False
                 op.mismatched_probe_indexes = ''
 
@@ -675,7 +698,8 @@ class ReflectionProbe(HubsComponent):
         type=Image
     )
 
-    locked: BoolProperty(name="Probe Lock", description="Toggle whether new environment maps can be assigned/baked to this reflection probe", default=False)
+    locked: BoolProperty(
+        name="Probe Lock", description="Toggle whether new environment maps can be assigned/baked to this reflection probe", default=False)
 
     def draw(self, context, layout, panel):
         row = layout.row()
@@ -688,7 +712,8 @@ class ReflectionProbe(HubsComponent):
                   icon='INFO')
         row = layout.row(align=True)
         row.prop(self, "envMapTexture")
-        row.operator("image.hubs_open_reflection_probe_envmap", text='', icon='FILE_FOLDER')
+        row.operator("image.hubs_open_reflection_probe_envmap",
+                     text='', icon='FILE_FOLDER')
 
         if self.locked:
             row.enabled = False
@@ -701,12 +726,12 @@ class ReflectionProbe(HubsComponent):
                 row = layout.row()
                 row.alert = True
                 row.label(text="Can't load image.",
-                            icon='ERROR')
+                          icon='ERROR')
             elif envmap_resolution != props.resolution:
                 row = layout.row()
                 row.alert = True
                 row.label(text=f"{envmap_resolution} EnvMap doesn't match the scene probe resolution.",
-                            icon='ERROR')
+                          icon='ERROR')
 
         global bake_mode
         row = layout.row()
@@ -762,15 +787,17 @@ class ReflectionProbe(HubsComponent):
                     row = col.row()
                     row.alert = True
                     row.label(text="Reflection probe resolution has changed. Bake again to apply the new resolution.",
-                            icon='ERROR')
+                              icon='ERROR')
                 row = col.row()
                 row.alert = True
                 row.label(text=f"{mismatched_probes} probes don't match the current resolution.",
-                        icon='ERROR')
-                row.operator("wm.hubs_select_mismatched_reflection_probes", text="", icon='RESTRICT_SELECT_OFF')
+                          icon='ERROR')
+                row.operator("wm.hubs_select_mismatched_reflection_probes",
+                             text="", icon='RESTRICT_SELECT_OFF')
 
             row = col.row()
-            row.prop(context.scene.hubs_scene_reflection_probe_properties, "use_compositor")
+            row.prop(
+                context.scene.hubs_scene_reflection_probe_properties, "use_compositor")
 
             global bake_mode
 

--- a/addons/io_hubs_addon/components/definitions/reflection_probe.py
+++ b/addons/io_hubs_addon/components/definitions/reflection_probe.py
@@ -217,6 +217,7 @@ class BakeProbeOperator(Operator):
         bpy.context.scene.collection.objects.link(self.camera_object)
 
         self.saved_props = {}
+        self.preferences_is_dirty_state = bpy.context.preferences.is_dirty
         self.cancelled = False
         self.done = False
         self.rendering = False
@@ -317,6 +318,8 @@ class BakeProbeOperator(Operator):
     def restore_render_props(self):
         for prop in self.saved_props:
            rsetattr(bpy.context, prop, self.saved_props[prop])
+        bpy.context.preferences.is_dirty = self.preferences_is_dirty_state
+        self.preferences_is_dirty_state = None
 
     def setup_probe_render(self, context):
         probe = self.probes[self.probe_index]

--- a/addons/io_hubs_addon/components/definitions/reflection_probe.py
+++ b/addons/io_hubs_addon/components/definitions/reflection_probe.py
@@ -142,6 +142,16 @@ class BakeProbeOperator(Operator):
         default='ACTIVE')
 
     @ classmethod
+    def description(cls, context, properties):
+        if properties.bake_mode == 'ACTIVE':
+            description_text = "Generate a 360 equirectangular HDR environment map of the current area in the scene"
+        elif properties.bake_mode == 'SELECTED':
+            description_text = "Bake the selected unlocked reflection probes"
+        else:
+            description_text = "Bake all the unlocked reflection probes in the current view layer"
+        return description_text
+
+    @ classmethod
     def poll(cls, context):
         return not probe_baking and hasattr(bpy.context.scene, "cycles")
 

--- a/addons/io_hubs_addon/components/definitions/reflection_probe.py
+++ b/addons/io_hubs_addon/components/definitions/reflection_probe.py
@@ -247,6 +247,10 @@ class BakeProbeOperator(Operator):
                 self.probe_is_setup = False
 
                 if self.cancelled:
+                    for probe in self.probes:
+                        img_path = get_probe_image_path(probe)
+                        if os.path.exists(img_path):
+                            os.remove(img_path)
                     self.report(
                         {'WARNING'}, 'Reflection probe baking cancelled')
                     return {"CANCELLED"}

--- a/addons/io_hubs_addon/components/definitions/reflection_probe.py
+++ b/addons/io_hubs_addon/components/definitions/reflection_probe.py
@@ -627,7 +627,12 @@ class ReflectionProbe(HubsComponent):
         if envmap:
             envmap_resolution = f"{envmap.size[0]}x{envmap.size[1]}"
             props = context.scene.hubs_scene_reflection_probe_properties
-            if envmap_resolution != props.resolution:
+            if not envmap.has_data:
+                row = layout.row()
+                row.alert = True
+                row.label(text="Can't load image.",
+                            icon='ERROR')
+            elif envmap_resolution != props.resolution:
                 row = layout.row()
                 row.alert = True
                 row.label(text="EnvMap/Probe resolution mismatch.",

--- a/addons/io_hubs_addon/components/utils.py
+++ b/addons/io_hubs_addon/components/utils.py
@@ -112,3 +112,7 @@ def redraw_component_ui(context):
         for area in window.screen.areas:
             if area.type == 'PROPERTIES':
                 area.tag_redraw()
+
+
+def is_linked(datablock):
+    return datablock.library or datablock.override_library

--- a/addons/io_hubs_addon/preferences.py
+++ b/addons/io_hubs_addon/preferences.py
@@ -21,19 +21,11 @@ class HubsPreferences(AddonPreferences):
         min=0,
     )
 
-    tmp_path: StringProperty(
-        name="Temporary files path",
-        description="Path where temporary files will be stored",
-        subtype="DIR_PATH",
-        default="//generated_cubemaps/"
-    )
-
     def draw(self, context):
         layout = self.layout
         box = layout.box()
 
         box.row().prop(self, "row_length")
-        box.row().prop(self, "tmp_path")
 
 
 def register():


### PR DESCRIPTION
Instead of baking the files to an output directory, this PR bakes them to Blender's session temp directory and then immediately packs and discards them.  This allows Blender to do all of the file management for us and will never be in danger of overwriting another blend file's reflection probe bakes.  Bakes of the same name will essentially be overwritten the same way they are now.  Baking to a new probe name still won't overwrite the previous bake, but the image will only hang around until the blend file has been saved and opened again (provided it has no users), so I consider that a small improvement.  Because we're now dealing with only Blender's internal "file system" I've had to account for a few things that we didn't have to when outputting to a permanent folder, but it's also allowed the opportunity to stabilize and improve a few things.

- I've managed to reduce the chance of accidental overwrites of the wrong probe when Blender juggles names to keep everything unique, and make it easier to see that this is what Blender has done.  This doesn't completely prevent the possibility of accidental overwrites, but to do that would require a naming scheme change and a migration, so this would need to happen later.  See the relevant commit for more details.
- I found the reason for that delay needed between renders and prevented it from occasionally deadlocking.
- I added export, import, and open functionality for interoperability with outside compositing/image editing applications.  When the bakes were output to the file system anything could easily use them, but now that they're packed, specific IO functionality was needed to accommodate this, plus it's nice to be able to just open any file and add it to a probe.
- I added the ability to lock probes, i.e. prevent their environment maps from being rebaked/changed.  This was needed to prevent accidental overwrites of linked/appended images when their names conflict with probes (these kinds of accidental overwrites weren't possible when the bakes were stored on the file system), and it's overall a nice feature to have.
- I fixed a case where the bake operator would still try to bake even though there weren't any valid probes (e.g. baking selected, but none of the selected objects were probes)
- I've added warnings for probes that don't match the specified resolution and provided an operator to select these.  Before the addition of locking just displaying the warning on resolution changes would do, but since baking would skip locked probes and you could end up with an invalid state but no warning, additional warnings needed to be added to accommodate this.
- I've added in a warning for image data-blocks that can't load their image, e.g. if a non-packed file had an invalid file path.
- I've added tooltips to the bake operator to clarify what gets baked, e.g. bake all only bakes all the probes in the current view layer.
- I prevented the saved state of the preferences from changing when baking, e.g. before this change baking would always mark the preferences as changed and in need of saving, when auto-save preferences was off, but now it will be put back to it's previous state.
- And I've added in support for linked probes, by which I mean notifying the user that linked probes can't be baked/changed (which keeps it consistent with the behavior of other linked components) and linked probes are skipped on bake/import/export.

I also removed the tmp_path preference as it wasn't needed any more when storing the bakes inside the blend file.

Overall I've found this approach to be much stabler/nicer, the only downside is that now each blend file will contain a copy of all the reflection probe environment maps, which increases their file size, but since reflection probe images are generally small I don't think it will bloat things too much.

Note: After packing, the stored file path is changed to be relative to the blend file so that it's simpler and more pleasant to use, however this causes an error to be printed to the terminal, but everything works fine so it seems it can just be ignored.  If anyone's really worried about it we can just not change the file path and leave it pointing to the old temp directory, which won't look as nice, but would prevent it printing erroneous errors to the terminal. (My vote goes to just ignoring the fake errors)

Alternatives I considered: #154 #155