### PR TITLE
Support linked Pointer Properties in Blender 3.2+

### DIFF
--- a/addons/io_hubs_addon/components/definitions/audio_target.py
+++ b/addons/io_hubs_addon/components/definitions/audio_target.py
@@ -1,8 +1,9 @@
 from email.policy import default
 from bpy.props import FloatProperty, BoolProperty, PointerProperty, EnumProperty, StringProperty
 from ..hubs_component import HubsComponent
-from ..utils import has_component
+from ..utils import has_component, is_linked
 from ..types import Category, PanelType, NodeType
+from ..ui import add_link_indicator
 from bpy.types import Object
 from ...io.utils import gather_joint_property, gather_node_property, delayed_gather
 from .audio_source import AudioSource
@@ -125,7 +126,17 @@ class AudioTarget(HubsComponent):
 
         has_obj_component = False
         has_bone_component = False
-        layout.prop(data=self, property="srcNode")
+        row = layout.row(align=True)
+        sub_row = row.row(align=True)
+        sub_row.prop(data=self, property="srcNode")
+        if is_linked(context.active_object):
+            # Manually disable the PointerProperty, needed for Blender 3.2+.
+            sub_row.enabled = False
+        if is_linked(self.srcNode):
+            sub_row = row.row(align=True)
+            sub_row.enabled = False
+            add_link_indicator(sub_row, self.srcNode)
+
         if hasattr(self.srcNode, 'type'):
             has_obj_component = has_component(self.srcNode, dep_name)
             if self.srcNode.type == 'ARMATURE':

--- a/addons/io_hubs_addon/components/definitions/environment_settings.py
+++ b/addons/io_hubs_addon/components/definitions/environment_settings.py
@@ -3,6 +3,8 @@ from bpy.types import Image
 from ...io.utils import gather_texture_property, gather_color_property
 from ..hubs_component import HubsComponent
 from ..types import Category, PanelType, NodeType
+from ..utils import is_linked
+from ..ui import add_link_indicator
 
 
 TOME_MAPPING = [("NoToneMapping", "None", "No tone mapping"),
@@ -81,8 +83,28 @@ class EnvironmentSettings(HubsComponent):
         layout.prop(data=self, property="enableHDRPipeline")
 
         layout.prop(data=self, property="backgroundColor")
-        layout.prop(data=self, property="backgroundTexture")
-        layout.prop(data=self, property="envMapTexture")
+
+        row = layout.row(align=True)
+        sub_row = row.row(align=True)
+        sub_row.prop(data=self, property="backgroundTexture")
+        if is_linked(context.scene):
+            # Manually disable the PointerProperty, needed for Blender 3.2+.
+            sub_row.enabled = False
+        if is_linked(self.backgroundTexture):
+            sub_row = row.row(align=True)
+            sub_row.enabled = False
+            add_link_indicator(sub_row, self.backgroundTexture)
+
+        row = layout.row(align=True)
+        sub_row = row.row(align=True)
+        sub_row.prop(data=self, property="envMapTexture")
+        if is_linked(context.scene):
+            # Manually disable the PointerProperty, needed for Blender 3.2+.
+            sub_row.enabled = False
+        if is_linked(self.envMapTexture):
+            sub_row = row.row(align=True)
+            sub_row.enabled = False
+            add_link_indicator(sub_row, self.envMapTexture)
 
         layout.prop(data=self, property="toneMapping")
         layout.prop(data=self, property="toneMappingExposure")

--- a/addons/io_hubs_addon/components/definitions/reflection_probe.py
+++ b/addons/io_hubs_addon/components/definitions/reflection_probe.py
@@ -2,7 +2,7 @@ import bpy
 from bpy.props import PointerProperty, EnumProperty, StringProperty, BoolProperty, CollectionProperty
 from bpy.types import Image, PropertyGroup, Operator
 
-from ...components.utils import is_gpu_available
+from ...components.utils import is_gpu_available, redraw_component_ui, is_linked
 
 from ...preferences import get_addon_pref
 from ...io.gltf_exporter import glTF2ExportUserExtension
@@ -13,7 +13,6 @@ from ..types import Category, PanelType, NodeType
 from ..ui import add_link_indicator
 from ... import io
 from ...utils import rgetattr, rsetattr
-from ..utils import redraw_component_ui, is_linked
 import math
 import os
 

--- a/addons/io_hubs_addon/components/definitions/reflection_probe.py
+++ b/addons/io_hubs_addon/components/definitions/reflection_probe.py
@@ -10,6 +10,7 @@ from ...io.gltf_exporter import glTF2ExportUserExtension
 from ..components_registry import get_components_registry
 from ..hubs_component import HubsComponent
 from ..types import Category, PanelType, NodeType
+from ..ui import add_link_indicator
 from ... import io
 from ...utils import rgetattr, rsetattr
 from ..utils import redraw_component_ui, is_linked
@@ -750,8 +751,18 @@ class ReflectionProbe(HubsComponent):
         row.label(
             text="Resolution settings, as well as the option to bake all reflection probes at once, can be accessed from the scene settings.",
             icon='INFO')
+
         row = layout.row(align=True)
-        row.prop(self, "envMapTexture")
+        sub_row = row.row(align=True)
+        sub_row.prop(self, "envMapTexture")
+        if is_linked(context.active_object):
+            # Manually disable the PointerProperty, needed for Blender 3.2+.
+            sub_row.enabled = False
+
+        if is_linked(self.envMapTexture):
+            sub_row = row.row(align=True)
+            sub_row.enabled = False
+            add_link_indicator(sub_row, self.envMapTexture)
         row.operator("image.hubs_open_reflection_probe_envmap",
                      text='', icon='FILE_FOLDER')
 

--- a/addons/io_hubs_addon/components/definitions/video_texture_target.py
+++ b/addons/io_hubs_addon/components/definitions/video_texture_target.py
@@ -1,7 +1,8 @@
 from bpy.props import BoolProperty, PointerProperty, EnumProperty, StringProperty
 from ..hubs_component import HubsComponent
 from ..types import Category, PanelType, NodeType
-from ..utils import has_component
+from ..utils import has_component, is_linked
+from ..ui import add_link_indicator
 from bpy.types import Object
 from ...io.utils import gather_joint_property, gather_node_property, delayed_gather
 from .video_texture_source import VideoTextureSource
@@ -112,7 +113,16 @@ class VideoTextureTarget(HubsComponent):
 
         has_obj_component = False
         has_bone_component = False
-        layout.prop(data=self, property="srcNode")
+        row = layout.row(align=True)
+        sub_row = row.row(align=True)
+        sub_row.prop(data=self, property="srcNode")
+        if is_linked(self.id_data):
+            # Manually disable the PointerProperty, needed for Blender 3.2+.
+            sub_row.enabled = False
+        if is_linked(self.srcNode):
+            sub_row = row.row(align=True)
+            sub_row.enabled = False
+            add_link_indicator(sub_row, self.srcNode)
         if hasattr(self.srcNode, 'type'):
             has_obj_component = has_component(self.srcNode, dep_name)
             if self.srcNode.type == 'ARMATURE':

--- a/addons/io_hubs_addon/components/ui.py
+++ b/addons/io_hubs_addon/components/ui.py
@@ -1,4 +1,5 @@
 import bpy
+from bpy.props import StringProperty
 from .types import PanelType
 from .components_registry import get_component_by_name, get_components_registry
 from .utils import get_object_source, dash_to_title
@@ -86,6 +87,25 @@ def draw_components_list(panel, context):
     layout.separator()
 
 
+def add_link_indicator(layout, datablock):
+    if datablock.library:
+        library = datablock.library
+        icon = 'LINKED'
+    else:
+        library = datablock.override_library.reference.library
+        icon = 'LIBRARY_DATA_OVERRIDE'
+
+    tooltip = (
+        f"{datablock.name}\n"
+        f"\n"
+        f"Source Library:\n"
+        f"[{library.name}]\n"
+        f"{library.filepath}"
+    )
+    layout.operator("ui.hubs_tooltip_label", text='',
+                    icon=icon).tooltip = tooltip
+
+
 class HubsObjectPanel(bpy.types.Panel):
     bl_label = "Hubs"
     bl_idname = "OBJECT_PT_hubs"
@@ -133,11 +153,26 @@ class HubsBonePanel(bpy.types.Panel):
         draw_components_list(self, context)
 
 
+class TooltipLabel(bpy.types.Operator):
+    bl_idname = "ui.hubs_tooltip_label"
+    bl_label = "---"
+
+    tooltip: StringProperty(default=" ")
+
+    @ classmethod
+    def description(cls, context, properties):
+        return properties.tooltip
+
+    def execute(self, context):
+        return {'CANCELLED'}
+
+
 def register():
     bpy.utils.register_class(HubsObjectPanel)
     bpy.utils.register_class(HubsScenePanel)
     bpy.utils.register_class(HubsMaterialPanel)
     bpy.utils.register_class(HubsBonePanel)
+    bpy.utils.register_class(TooltipLabel)
 
 
 def unregister():
@@ -145,3 +180,4 @@ def unregister():
     bpy.utils.unregister_class(HubsScenePanel)
     bpy.utils.unregister_class(HubsMaterialPanel)
     bpy.utils.unregister_class(HubsBonePanel)
+    bpy.utils.unregister_class(TooltipLabel)

--- a/addons/io_hubs_addon/components/utils.py
+++ b/addons/io_hubs_addon/components/utils.py
@@ -115,4 +115,6 @@ def redraw_component_ui(context):
 
 
 def is_linked(datablock):
+    if not datablock:
+        return False
     return datablock.library or datablock.override_library


### PR DESCRIPTION
This PR properly disables pointer properties when they're part of linked components in Blender 3.2+ and also adds a disabled indicator button to the left of the pointer property field to inform the user whether the selected data-block is linked or a link_override (via differing icons) and displays the source library name/path in a tooltip.  Note: The link indicator button is needed for Blender versions before 3.2 as well because Blender doesn't always show the source library in its default tooltips.

To add the link indicator I created a generic tooltip label operator that functions similarly to a regular label, but will open a custom tooltip when hovered.  Note: this can be used anywhere a label can be and I think it'll probably be useful in other places for warnings that are currently being truncated, but would look too busy wrapped.

There are several intricacies when it comes to Blender displaying tooltips and how I have the tooltip label set up:
- If the text of the tooltip label is being truncated in the UI then the first line of the tooltip will show the text without truncation.
- If the tooltip label isn't being truncated, then the first line will contain three dashes, provided the tooltip has custom text, otherwise the first line will be blank.
- If there is no custom text, the tooltip will display a single period in the second line (Blender automatically adds one by default).
- Multi-line tooltips are a thing, just add new line characters to your string. (But colors and/or formatting sadly aren't)

Alternatives I considered:
Using the tooltip label to display the library name underneath the pointer property with the full path displayed in the tooltip.  However, this made the component take up more space and was visually noisier.