### PR TITLE
Exclude hubs components from extras creation

### DIFF
--- a/addons/io_hubs_addon/__init__.py
+++ b/addons/io_hubs_addon/__init__.py
@@ -18,15 +18,15 @@ bl_info = {
 
 def register():
     preferences.register()
-    gltf_exporter.register()
     nodes.register()
     components.register()
+    gltf_exporter.register()
 
 
 def unregister():
+    gltf_exporter.unregister()
     components.unregister()
     nodes.unregister()
-    gltf_exporter.unregister()
     preferences.unregister()
 
 

--- a/addons/io_hubs_addon/components/components_registry.py
+++ b/addons/io_hubs_addon/components/components_registry.py
@@ -78,6 +78,9 @@ def register_component(component_class):
             PointerProperty(type=component_class)
         )
 
+    from ..io.gltf_exporter import glTF2ExportUserExtension
+    glTF2ExportUserExtension.add_excluded_property(component_class.get_id())
+
 
 def unregister_component(component_class):
     component_id = component_class.get_id()
@@ -91,6 +94,9 @@ def unregister_component(component_class):
         delattr(bpy.types.Material, component_id)
 
     bpy.utils.unregister_class(component_class)
+
+    from ..io.gltf_exporter import glTF2ExportUserExtension
+    glTF2ExportUserExtension.remove_excluded_property(component_class.get_id())
 
     print("Component unregistered: " + component_class.get_name())
 

--- a/addons/io_hubs_addon/components/components_registry.py
+++ b/addons/io_hubs_addon/components/components_registry.py
@@ -176,6 +176,9 @@ def register():
     bpy.types.EditBone.hubs_component_list = PointerProperty(
         type=HubsComponentList)
 
+    from ..io.gltf_exporter import glTF2ExportUserExtension
+    glTF2ExportUserExtension.add_excluded_property("hubs_component_list")
+
 
 def unregister():
     del bpy.types.Object.hubs_component_list
@@ -186,6 +189,9 @@ def unregister():
 
     bpy.utils.unregister_class(HubsComponentName)
     bpy.utils.unregister_class(HubsComponentList)
+
+    from ..io.gltf_exporter import glTF2ExportUserExtension
+    glTF2ExportUserExtension.remove_excluded_property("hubs_component_list")
 
     unload_components_registry()
     unload_icons()

--- a/addons/io_hubs_addon/components/definitions/reflection_probe.py
+++ b/addons/io_hubs_addon/components/definitions/reflection_probe.py
@@ -5,6 +5,7 @@ from bpy.types import Image, PropertyGroup
 from ...components.utils import is_gpu_available
 
 from ...preferences import get_addon_pref
+from ...io.gltf_exporter import glTF2ExportUserExtension
 
 from ..components_registry import get_components_registry
 from ..hubs_component import HubsComponent
@@ -394,9 +395,11 @@ class ReflectionProbe(HubsComponent):
         bpy.utils.register_class(ReflectionProbeSceneProps)
         bpy.types.Scene.hubs_scene_reflection_probe_properties = PointerProperty(
             type=ReflectionProbeSceneProps)
+        glTF2ExportUserExtension.add_excluded_property("hubs_scene_reflection_probe_properties")
 
     @ staticmethod
     def unregister():
         bpy.utils.unregister_class(BakeProbeOperator)
         bpy.utils.unregister_class(ReflectionProbeSceneProps)
         del bpy.types.Scene.hubs_scene_reflection_probe_properties
+        glTF2ExportUserExtension.remove_excluded_property("hubs_scene_reflection_probe_properties")

--- a/addons/io_hubs_addon/components/utils.py
+++ b/addons/io_hubs_addon/components/utils.py
@@ -21,7 +21,7 @@ def add_component(obj, component_name):
                 if not dep_exists:
                     add_component(obj, dep_name)
             else:
-                print("Dependecy '%s' from module '%s' not registered" %
+                print("Dependency '%s' from module '%s' not registered" %
                       (dep_name, component_name))
 
 

--- a/addons/io_hubs_addon/io/gltf_exporter.py
+++ b/addons/io_hubs_addon/io/gltf_exporter.py
@@ -2,6 +2,7 @@ import bpy
 from bpy.props import PointerProperty, IntVectorProperty
 from ..components.components_registry import get_components_registry
 from .utils import gather_lightmap_texture_info
+from io_scene_gltf2.blender.com.gltf2_blender_extras import BLACK_LIST
 
 hubs_config = {
     "gltfExtensionName": "MOZ_hubs_components",
@@ -73,6 +74,9 @@ class glTF2ExportUserExtension:
         self.was_used = False
         self.delayed_gathers = []
 
+        for _, component_class in get_components_registry().items():
+            BLACK_LIST.append(component_class.get_id())
+
     def hubs_gather_gltf_hook(self, gltf2_object, export_settings):
         if not self.properties.enabled or not self.was_used:
             return
@@ -99,24 +103,12 @@ class glTF2ExportUserExtension:
         if not self.properties.enabled:
             return
 
-        # Don't include hubs component data again in extras, even if "include custom properties" is enabled
-        if gltf2_object.extras:
-            for key in list(gltf2_object.extras):
-                if key.startswith("hubs_"):
-                    del gltf2_object.extras[key]
-
         self.add_hubs_components(gltf2_object, blender_scene, export_settings)
         self.call_delayed_gathers()
 
     def gather_node_hook(self, gltf2_object, blender_object, export_settings):
         if not self.properties.enabled:
             return
-
-        # Don't include hubs component data again in extras, even if "include custom properties" is enabled
-        if gltf2_object.extras:
-            for key in list(gltf2_object.extras):
-                if key.startswith("hubs_"):
-                    del gltf2_object.extras[key]
 
         self.add_hubs_components(gltf2_object, blender_object, export_settings)
 

--- a/tests/export_gltf.py
+++ b/tests/export_gltf.py
@@ -40,7 +40,8 @@ try:
 
         'export_format': ('GLB' if extension == '.glb' else 'GLTF_SEPARATE'),
         'filepath': os.path.join(output_dir, path_parts[1]),
-        'export_cameras': True
+        'export_cameras': True,
+        'export_extras': True
     }
     bpy.ops.export_scene.gltf(**args)
 except Exception as err:


### PR DESCRIPTION
Fixes #80 

This PR avoids hubs components serialization when the "Export custom properties as glTF extras" glTF export option is enabled. We were manually removing them from the output glTF before but this didn't avoid serialization issues reported in the linked issue.

This ia a bit hacky and it's not using a public API. I've opened an issue (and I'll open a PR too) so this is fixed on the glTF add-on side if possible as it will probably break as soon as that code is updated on the add-on side:
https://github.com/KhronosGroup/glTF-Blender-IO/issues/1796