### PR TITLE
Video-texture-target load slowdown

### DIFF
--- a/addons/io_hubs_addon/components/components_registry.py
+++ b/addons/io_hubs_addon/components/components_registry.py
@@ -9,6 +9,7 @@ import inspect
 import os
 from os import listdir
 from os.path import join, isfile, isdir, dirname, realpath
+import pyclbr
 
 from .hubs_component import HubsComponent
 
@@ -101,7 +102,7 @@ def load_components_registry():
     __components_registry = {}
     for module in get_component_definitions():
         for _, member in inspect.getmembers(module):
-            if inspect.isclass(member) and issubclass(member, HubsComponent) and member != HubsComponent:
+            if inspect.isclass(member) and issubclass(member, HubsComponent) and module.__name__ == member.__module__:
                 if hasattr(module, 'register_module'):
                     module.register_module()
                 register_component(member)

--- a/addons/io_hubs_addon/components/components_registry.py
+++ b/addons/io_hubs_addon/components/components_registry.py
@@ -9,7 +9,6 @@ import inspect
 import os
 from os import listdir
 from os.path import join, isfile, isdir, dirname, realpath
-import pyclbr
 
 from .hubs_component import HubsComponent
 

--- a/addons/io_hubs_addon/components/definitions/audio_target.py
+++ b/addons/io_hubs_addon/components/definitions/audio_target.py
@@ -5,12 +5,13 @@ from ..utils import has_component
 from ..types import Category, PanelType, NodeType
 from bpy.types import Object
 from ...io.utils import gather_joint_property, gather_node_property, delayed_gather
+from .audio_source import AudioSource
+
 
 BLANK_ID = "374e54CMHFCipSk"
 
 
 def filter_on_component(self, ob):
-    from .audio_source import AudioSource
     dep_name = AudioSource.get_name()
     if hasattr(ob, 'type') and ob.type == 'ARMATURE':
         if ob.mode == 'EDIT':
@@ -29,7 +30,6 @@ def get_bones(self, context):
     global bones
     bones = []
     count = 0
-    from .audio_source import AudioSource
     dep_name = AudioSource.get_name()
     bones.append((BLANK_ID, "Select a bone", "None", "BLANK", count))
     count += 1
@@ -120,7 +120,6 @@ class AudioTarget(HubsComponent):
         default=False)
 
     def draw(self, context, layout, panel):
-        from .audio_source import AudioSource
         dep_name = AudioSource.get_name()
 
         has_obj_component = False

--- a/addons/io_hubs_addon/components/definitions/personal_space_invader.py
+++ b/addons/io_hubs_addon/components/definitions/personal_space_invader.py
@@ -3,7 +3,7 @@ from ..hubs_component import HubsComponent
 from ..types import Category, PanelType, NodeType
 
 
-class AmbientLight(HubsComponent):
+class PersonalSpaceInvader(HubsComponent):
     _definition = {
         'name': 'personal-space-invader',
         'display_name': 'Personal Space Invader',

--- a/addons/io_hubs_addon/components/definitions/video_texture_target.py
+++ b/addons/io_hubs_addon/components/definitions/video_texture_target.py
@@ -4,12 +4,12 @@ from ..types import Category, PanelType, NodeType
 from ..utils import has_component
 from bpy.types import Object
 from ...io.utils import gather_joint_property, gather_node_property, delayed_gather
+from .video_texture_source import VideoTextureSource
 
 BLANK_ID = "pXph8WBzMu9fung"
 
 
 def filter_on_component(self, ob):
-    from .video_texture_source import VideoTextureSource
     dep_name = VideoTextureSource.get_name()
     if hasattr(ob, 'type') and ob.type == 'ARMATURE':
         if ob.mode == 'EDIT':
@@ -28,7 +28,6 @@ def get_bones(self, context):
     global bones
     bones = []
     count = 0
-    from .video_texture_source import VideoTextureSource
     dep_name = VideoTextureSource.get_name()
     bones.append((BLANK_ID, "Select a bone", "None", "BLANK", count))
     count += 1
@@ -108,7 +107,6 @@ class VideoTextureTarget(HubsComponent):
         options={'HIDDEN'})
 
     def draw(self, context, layout, panel):
-        from .video_texture_source import VideoTextureSource
         dep_name = VideoTextureSource.get_name()
 
         has_obj_component = False


### PR DESCRIPTION
This PR tries to address the video-texture-target import slowdown by improving the modules import process to only register the class that is contained in the currently iterated module.

I think though that there is something else going on with this slowdown that I couldn't really find.