### PR TITLE
Limit Cone Outer Gain to the 0-1 range.

### DIFF
--- a/addons/io_hubs_addon/components/definitions/audio_params.py
+++ b/addons/io_hubs_addon/components/definitions/audio_params.py
@@ -86,7 +86,8 @@ class AudioParams(HubsComponent):
         name="Cone Outer Gain",
         description="A double value describing the amount of volume reduction outside the cone defined by the coneOuterAngle attribute",
         default=0.0,
-        min=0.0)
+        min=0.0,
+        max=1.0)
 
     def gather(self, export_settings, object):
         if (self.overrideAudioSettings):

--- a/addons/io_hubs_addon/components/definitions/audio_settings.py
+++ b/addons/io_hubs_addon/components/definitions/audio_settings.py
@@ -93,7 +93,8 @@ class AudioSettings(HubsComponent):
         name="Media Cone Outer Gain",
         description="Media Cone Outer Gain",
         default=0.0,
-        min=0.0)
+        min=0.0,
+        max=1.0)
 
     def gather(self, export_settings, object):
         return {


### PR DESCRIPTION
Hubs produces this error when trying to upload anything with a Cone Outer Gain higher than one: DOMException: PannerNode.coneOuterGain setter: <number> is not in the range [0, 1]

I happened across this while testing #167

Edit: I don't think this should require any kind of migration because values above one fail in Hubs.