### PR TITLE
Fix gather_joint_property error in Blender 3.2+ when getting the vnode.

### DIFF
--- a/addons/io_hubs_addon/io/utils.py
+++ b/addons/io_hubs_addon/io/utils.py
@@ -232,7 +232,7 @@ def gather_joint_property(export_settings, blender_object, target, property_name
         else:
             vtree = export_settings['vtree']
             vnode = vtree.nodes[next((uuid for uuid in vtree.nodes if (
-                vtree.nodes[uuid].joint == joint)), None)]
+                vtree.nodes[uuid].blender_bone == joint)), None)]
             node = vnode.node or gltf2_blender_gather_joints.gather_joint_vnode(
                 vnode,
                 export_settings


### PR DESCRIPTION
Fixes #170

When looking for the equivalent vnode for the bone being referenced, check the vnode's blender_bone, rather than the joint attribute which isn't present in Blender 3.2+.

While working on this, I noticed that the code to get the vnode in both `gather_joint_property` and `gather_node_property` would most likely fail if the vnode wasn't found, so I think it should either be changed to use `vtree.nodes.get(...)`, so that it'll safely fall back to None, or the vnode should be assumed to be present and the None fallback removed in `next(...)` and then just do `node = vnode.node` and forget the whole `or gather` part.