### PR TITLE
Reset the bone EnumProperty when the srcNode PointerProperty changes.

### DIFF
--- a/addons/io_hubs_addon/components/definitions/audio_target.py
+++ b/addons/io_hubs_addon/components/definitions/audio_target.py
@@ -86,7 +86,8 @@ class AudioTarget(HubsComponent):
         name="Source",
         description="The object with an audio-source component to pull audio from",
         type=Object,
-        poll=filter_on_component
+        poll=filter_on_component,
+        update=lambda self, context: setattr(self, 'bone', BLANK_ID)
     )
 
     bone: EnumProperty(

--- a/addons/io_hubs_addon/components/definitions/video_texture_target.py
+++ b/addons/io_hubs_addon/components/definitions/video_texture_target.py
@@ -91,7 +91,8 @@ class VideoTextureTarget(HubsComponent):
         name="Source",
         description="The object with a video-texture-source component to pull video from",
         type=Object,
-        poll=filter_on_component)
+        poll=filter_on_component,
+        update=lambda self, context: setattr(self, 'bone', BLANK_ID))
 
     bone: EnumProperty(
         name="Bone",


### PR DESCRIPTION
Fixes #172

This also improves usability because I think having the bone be reset when choosing an object is more in line with what a user would expect.

I considered checking whether the object was an armature and only gathering bones if that was the case, but decided against that route because it is more complex, not as future proof, and wouldn't provide the usability improvement.