### PR TITLE
Fix error when clearing the srcNode property in audio and video texture target components.

### DIFF
--- a/addons/io_hubs_addon/components/definitions/audio_target.py
+++ b/addons/io_hubs_addon/components/definitions/audio_target.py
@@ -34,7 +34,7 @@ def get_bones(self, context):
     bones.append((BLANK_ID, "Select a bone", "None", "BLANK", count))
     count += 1
 
-    if self.srcNode.mode == 'EDIT':
+    if self.srcNode and self.srcNode.mode == 'EDIT':
         self.srcNode.update_from_editmode()
 
     found = False

--- a/addons/io_hubs_addon/components/definitions/video_texture_target.py
+++ b/addons/io_hubs_addon/components/definitions/video_texture_target.py
@@ -32,7 +32,7 @@ def get_bones(self, context):
     bones.append((BLANK_ID, "Select a bone", "None", "BLANK", count))
     count += 1
 
-    if self.srcNode.mode == 'EDIT':
+    if self.srcNode and self.srcNode.mode == 'EDIT':
         self.srcNode.update_from_editmode()
 
     found = False


### PR DESCRIPTION
Clearing the srcNode property triggers a reset of the bone EnumProperty, but this failed because of an unguarded check for the mode of the srcNode object when accessing the bone EnumProperty to reset it.  This PR adds a check for whether the srcNode has an object before checking whether the srcNode object is in edit mode so that resetting the bone EnumProperty to the blank id doesn't cause an error when getting the list of bones.