### PR TITLE
Fix typos/grammar in the scale warning message for ammo shapes and media frames.

### DIFF
--- a/addons/io_hubs_addon/components/definitions/ammo_shape.py
+++ b/addons/io_hubs_addon/components/definitions/ammo_shape.py
@@ -77,7 +77,7 @@ class AmmoShape(HubsComponent):
                 col = layout.column()
                 col.alert = True
                 col.label(
-                    text="The ammo-shape object, and it's parents, scale needs to be [1,1,1]", icon='ERROR')
+                    text="The ammo-shape object, and its parents' scale need to be [1,1,1]", icon='ERROR')
 
                 break
 

--- a/addons/io_hubs_addon/components/definitions/media_frame.py
+++ b/addons/io_hubs_addon/components/definitions/media_frame.py
@@ -169,7 +169,7 @@ class MediaFrame(HubsComponent):
                 col = layout.column()
                 col.alert = True
                 col.label(
-                    text="The media-frame object, and it's parents, scale needs to be [1,1,1]", icon='ERROR')
+                    text="The media-frame object, and its parents' scale need to be [1,1,1]", icon='ERROR')
 
                 break
 


### PR DESCRIPTION
Fix typos/grammar in the scale warning message for ammo shapes and media frames.