### PR TITLE
Improve UV scroll runtime checks

### DIFF
--- a/addons/io_hubs_addon/components/definitions/uv_scroll.py
+++ b/addons/io_hubs_addon/components/definitions/uv_scroll.py
@@ -25,11 +25,15 @@ class UVScroll(HubsComponent):
                                    subtype="XYZ",
                                    default=[0, 0])
 
+    @classmethod
+    def poll(cls, context, panel_type):
+        return hasattr(context.object.data, 'materials')
+
     def draw(self, context, layout, panel):
         has_texture = False
         for material in context.object.data.materials:
             for node in material.node_tree.nodes:
-                if node.type == 'TEX_IMAGE':
+                if node.type == 'TEX_IMAGE' and node.image != None:
                     has_texture = True
 
         super().draw(context, layout, panel)


### PR DESCRIPTION
This PR adds polling on the `uv-scroll` component so only objects that support materials can add the component. It also adds another check when checking for an existing image to also check if the image has actually been set.