### PR TITLE
Armature gizmo and migration fixes.

### DIFF
--- a/addons/io_hubs_addon/components/definitions/audio_params.py
+++ b/addons/io_hubs_addon/components/definitions/audio_params.py
@@ -114,7 +114,7 @@ class AudioParams(HubsComponent):
             self.coneOuterAngle = radians(
                 self.coneOuterAngle)
 
-            if migration_type != MigrationType.GLOBAL or is_linked(ob):
+            if migration_type != MigrationType.GLOBAL or is_linked(ob) or type(ob) == bpy.types.Armature:
                 host_reference = get_host_reference_message(panel_type, host, ob=ob)
                 migration_report.append(
                     f"Warning: The Media Cone angles may not have migrated correctly for the Audio Params component on the {panel_type.value} {host_reference}")

--- a/addons/io_hubs_addon/components/definitions/media_frame.py
+++ b/addons/io_hubs_addon/components/definitions/media_frame.py
@@ -127,7 +127,7 @@ class MediaFrame(HubsComponent):
             bounds = Vector((bounds.x, bounds.z, bounds.y))
             self.bounds = bounds
 
-            if migration_type != MigrationType.GLOBAL or is_linked(ob):
+            if migration_type != MigrationType.GLOBAL or is_linked(ob) or type(ob) == bpy.types.Armature:
                 host_reference = get_host_reference_message(panel_type, host, ob=ob)
                 migration_report.append(
                     f"Warning: The Media Frame component's Y and Z bounds on the {panel_type.value} {host_reference} may not have migrated correctly")

--- a/addons/io_hubs_addon/components/definitions/video_texture_source.py
+++ b/addons/io_hubs_addon/components/definitions/video_texture_source.py
@@ -1,4 +1,4 @@
-from ..utils import children_recursive
+from ..utils import children_recursive, get_host_reference_message
 from bpy.props import IntVectorProperty, IntProperty
 from ..hubs_component import HubsComponent
 from ..types import Category, PanelType, NodeType
@@ -36,11 +36,10 @@ class VideoTextureSource(HubsComponent):
 
     @classmethod
     def get_unsupported_host_message(cls, panel_type, host, ob=None):
+        host_reference = get_host_reference_message(panel_type, host, ob=ob)
         if panel_type == PanelType.BONE:
-            host_reference = f"\"{host.name}\" in \"{ob.name_full}\""
             object_message = ""
         else:
-            host_reference = f"\"{host.name_full}\""
             object_message = " aren't cameras themselves and"
 
         host_type = panel_type.value

--- a/addons/io_hubs_addon/components/gizmos.py
+++ b/addons/io_hubs_addon/components/gizmos.py
@@ -147,8 +147,9 @@ class HubsGizmoGroup(GizmoGroup):
                         self.update_object_gizmo(
                             component_name, ob, gizmo)
 
-                except ReferenceError:
-                    # This shouldn't happen, but if objects and widgets have gotten out of sync refresh the whole system.
+                except (ReferenceError, KeyError):
+                    # ReferenceErrors shouldn't happen, but if objects and widgets have gotten out of sync refresh the whole system.
+                    # KeyErrors can happen when an object's armature is changed, so refresh the whole system for this as well.
                     bpy.app.timers.register(update_gizmos)
                     return
 

--- a/addons/io_hubs_addon/components/handlers.py
+++ b/addons/io_hubs_addon/components/handlers.py
@@ -12,6 +12,8 @@ previous_undo_steps_dump = ""
 previous_undo_step_index = 0
 previous_window_setups = []
 file_loading = False
+msgbus_owners = []
+object_data_switched = False
 
 
 def migrate(component, migration_type, panel_type, host, migration_report, ob=None):
@@ -30,7 +32,14 @@ def migrate(component, migration_type, panel_type, host, migration_report, ob=No
 
         component.instance_version = definition_version
 
-    if panel_type not in component.__class__.get_panel_type() or not component.__class__.poll(panel_type, host, ob=ob):
+    try:
+        unsupported_host = panel_type not in component.__class__.get_panel_type(
+        ) or not component.__class__.poll(panel_type, host, ob=ob)
+    except Exception:
+        # The poll likely failed on an armature without an object.
+        unsupported_host = True
+
+    if unsupported_host:
         message = component.__class__.get_unsupported_host_message(panel_type, host, ob=ob)
         migration_report.append(message)
 
@@ -42,6 +51,7 @@ def migrate_components(
         override_report_title=""):
     migration_report = []
     migrated_linked_components = []
+    armature_objects = {}
     link_migration_occurred = False
     display_registration_message = False
 
@@ -85,23 +95,33 @@ def migrate_components(
                 migrated_linked_components.append(component_info)
 
         if ob.type == 'ARMATURE':
-            for bone in ob.data.bones:
-                for component in get_host_components(bone):
-                    try:
-                        was_migrated = migrate(
-                            component, migration_type, PanelType.BONE, bone, migration_report, ob=ob)
-                    except Exception as e:
-                        was_migrated = True
-                        error = f"Error: Migration failed for component {component.get_display_name()} on bone \"{bone.name}\" in \"{ob.name_full}\""
-                        migration_report.append(f"{error}\n{e} (See Blender's console for details)")
-                        print(error)
-                        traceback.print_exc()
+            if ob.mode == 'EDIT':
+                ob.update_from_editmode()
 
-                    display_registration_message |= was_migrated
-                    if was_migrated and is_linked(ob):
-                        link_migration_occurred = True
-                        component_info = f"{component.get_display_name()} component on bone \"{bone.name}\" in \"{ob.name_full}\""
-                        migrated_linked_components.append(component_info)
+            armature_name = ob.data.name_full
+            if armature_name not in armature_objects:
+                # Store the first object to use this armature for later when armatures are migrated (armatures can only be migrated once anyway)
+                armature_objects[armature_name] = ob
+
+    for armature in bpy.data.armatures:
+        ob = armature_objects.get(armature.name_full, armature)
+        for bone in armature.bones:
+            for component in get_host_components(bone):
+                try:
+                    was_migrated = migrate(
+                        component, migration_type, PanelType.BONE, bone, migration_report, ob=ob)
+                except Exception as e:
+                    was_migrated = True
+                    error = f"Error: Migration failed for component {component.get_display_name()} on bone \"{bone.name}\" in \"{ob.name_full}\""
+                    migration_report.append(f"{error}\n{e} (See Blender's console for details)")
+                    print(error)
+                    traceback.print_exc()
+
+                display_registration_message |= was_migrated
+                if was_migrated and is_linked(ob):
+                    link_migration_occurred = True
+                    component_info = f"{component.get_display_name()} component on bone \"{bone.name}\" in \"{ob.name_full}\""
+                    migrated_linked_components.append(component_info)
 
     for material in bpy.data.materials:
         for component in get_host_components(material):
@@ -192,6 +212,7 @@ def load_post(dummy):
     file_loading = True
 
     migrate_components(MigrationType.GLOBAL, do_beta_versioning=True)
+    register_msgbus()
 
 
 def find_active_undo_step_index(undo_steps):
@@ -206,10 +227,11 @@ def find_active_undo_step_index(undo_steps):
 
 
 @persistent
-def undo_stack_handler(dummy):
+def undo_stack_handler(dummy, depsgraph):
     global previous_undo_steps_dump
     global previous_undo_step_index
     global file_loading
+    global object_data_switched
 
     # Return if Blender isn't in a fully loaded state. (Prevents Blender crashing)
     if file_loading and not bpy.context.space_data:
@@ -300,6 +322,12 @@ def undo_stack_handler(dummy):
         task_scheduler.add('migrate_components')
         display_report = (step_type == 'DO')
 
+    # Handle specific depsgraph updates.
+    if depsgraph.id_type_updated('ARMATURE') and object_data_switched:
+        # Update gizmos when switching the armature for an object.
+        object_data_switched = False
+        task_scheduler.add('update_gizmos')
+
     # Execute the scheduled tasks.
     # Note: Blender seems to somehow be caching calls to update_gizmos, so having it as a scheduled task may not affect performance.  Calls to migrate_components are not cached by Blender.
     for task in task_scheduler:
@@ -330,6 +358,23 @@ def scene_and_view_layer_update_notifier(self, context):
         previous_window_setups = current_window_setups
 
 
+def register_msgbus():
+    global msgbus_owners
+    owner = object()
+    msgbus_owners.append(owner)
+
+    def msgbus_update(*args):
+        global object_data_switched
+        object_data_switched = True
+
+    bpy.msgbus.subscribe_rna(
+        key=(bpy.types.Object, "data"),
+        owner=owner,
+        args=(bpy.context,),
+        notify=msgbus_update,
+    )
+
+
 def register():
     global previous_undo_steps_dump
     global previous_undo_step_index
@@ -346,8 +391,12 @@ def register():
 
     bpy.types.TOPBAR_HT_upper_bar.append(scene_and_view_layer_update_notifier)
 
+    register_msgbus()
+
 
 def unregister():
+    global msgbus_owners
+
     if load_post in bpy.app.handlers.load_post:
         bpy.app.handlers.load_post.remove(load_post)
 
@@ -355,3 +404,7 @@ def unregister():
         bpy.app.handlers.depsgraph_update_post.remove(undo_stack_handler)
 
     bpy.types.TOPBAR_HT_upper_bar.remove(scene_and_view_layer_update_notifier)
+
+    for owner in msgbus_owners:
+        bpy.msgbus.clear_by_owner(owner)
+    msgbus_owners.clear()

--- a/addons/io_hubs_addon/components/hubs_component.py
+++ b/addons/io_hubs_addon/components/hubs_component.py
@@ -129,7 +129,7 @@ class HubsComponent(PropertyGroup):
         The instance_version argument represents the version of the component that will be migrated from, as a tuple.
         The host argument is what the component is attached to, object/bone.
         The migration_report argument is a list that you can append messages to and they will be displayed to the user after the migration has finished.
-        The ob argument is used for bone migrations and is the armature object that the bone is part of.  Note: this is passed for object migrations as well.
+        The ob argument is used for bone migrations and is the armature object that the bone is part of.  Note: this is passed for object migrations as well, and will fall back to passing the armature if the object isn't available.
         Returns a boolean to indicate whether a migration was performed.
         '''
         return False
@@ -151,13 +151,14 @@ class HubsComponent(PropertyGroup):
     def poll(cls, panel_type, host, ob=None):
         '''This method will return true if this component's shown be shown or run.
         This is currently called when checking if the component should be added to the components pop-up, when the components properties panel is drawn, and during migrations to warn about unsupported hosts.
-        The ob argument is guaranteed to be present only for objects/bones.'''
+        The ob argument is guaranteed to be present only for objects/bones, although it will fall back to using the armature for bones if the object isn't available.'''
         return True
 
     @classmethod
     def get_unsupported_host_message(cls, panel_type, host, ob=None):
         '''This method will return the message to use if this component isn't supported on this host.
-        This is currently called during migrations.'''
+        This is currently called during migrations.
+        The ob argument will fall back to an armature for bones if an object isn't available.'''
         from .utils import get_host_reference_message
         host_reference = get_host_reference_message(panel_type, host, ob=ob)
         host_type = panel_type.value

--- a/addons/io_hubs_addon/components/utils.py
+++ b/addons/io_hubs_addon/components/utils.py
@@ -279,8 +279,10 @@ def display_wrapped_text(layout, wrapped_text, *, heading_icon='NONE'):
 
 
 def get_host_reference_message(panel_type, host, ob=None):
+    '''The ob argument is used for bone hosts and is the armature object, but will fall back to the armature if the armature object isn't available.'''
     if panel_type == PanelType.BONE:
-        host_reference = f"\"{host.name}\" in \"{ob.name_full}\""
+        ob_type = "armature" if type(ob) == bpy.types.Armature else "object"
+        host_reference = f"\"{host.name}\" in {ob_type} \"{ob.name_full}\""
     else:
         host_reference = f"\"{host.name_full}\""
 


### PR DESCRIPTION
Depends on #182

This PR migrates armatures separately from objects and refreshes gizmos when switching an object's armature.
Armatures exist independently from objects and don't have to belong to one, so they need to be migrated independently as well.  Since this is the first time armatures not attached to objects would be migrated, warnings will be shown on any migrations of unattached armatures, and they aren't versioned as migrated from beta files either.  Bones are also now updated from edit mode so that none are missed, and the messages have been improved to specify whether it's a regular object that has the component or an unattached armature.  As far as I know, unattached armatures aren't exported, so migrations should be the only place that needs to account for them at this time.

Note: the gizmo refreshing isn't perfect, the user may still have to manually refresh the gizmos, but it's at least better and there are no longer any Python errors.

The relevant commit for this PR is the last one listed.