### PR TITLE
Fix generator

### DIFF
--- a/addons/io_hubs_addon/components/utils.py
+++ b/addons/io_hubs_addon/components/utils.py
@@ -226,6 +226,8 @@ def redirect_c_stdout(binary_stream):
 
 
 def get_host_components(host):
+    # Note: this used to be a generator but we detected some issues in Mac so we reverted to returning an array.
+    components = []
     for component_item in host.hubs_component_list.items:
         component_name = component_item.name
         component_class = get_component_by_name(component_name)
@@ -233,7 +235,8 @@ def get_host_components(host):
             continue
 
         component = getattr(host, component_class.get_id())
-        yield component
+        components.append(component)
+    return components
 
 
 def wrap_text(text, max_length=70):


### PR DESCRIPTION
This is a weird one. This generator was not working properly but only in MacOS. When iterating over the elements the generator exits randomly and not all elements are returned. We couldn't find the root cause and it seems to only happen in MacOs so for safety we reverted it back to just returning an array. As we are not dealing with big amounts of data here it shouldn't really been an issue.