### PR TITLE
Fix for Windows stdout issues

### DIFF
--- a/addons/io_hubs_addon/components/__init__.py
+++ b/addons/io_hubs_addon/components/__init__.py
@@ -1,7 +1,8 @@
-from . import (handlers, gizmos, components_registry, ui, operators)
+from . import (handlers, gizmos, components_registry, ui, operators, utils)
 
 
 def register():
+    utils.register()
     handlers.register()
     gizmos.register()
     components_registry.register()
@@ -15,3 +16,4 @@ def unregister():
     components_registry.unregister()
     gizmos.unregister()
     handlers.unregister()
+    utils.unregister()

--- a/addons/io_hubs_addon/components/utils.py
+++ b/addons/io_hubs_addon/components/utils.py
@@ -1,3 +1,4 @@
+import tempfile
 import bpy
 from .components_registry import get_component_by_name
 from .gizmos import update_gizmos
@@ -201,28 +202,28 @@ else:  # Linux/Mac
 def redirect_c_stdout(binary_stream):
     stdout_file_descriptor = sys.stdout.fileno()
     original_stdout_file_descriptor_copy = os.dup(stdout_file_descriptor)
-    pipe_read_end, pipe_write_end = os.pipe()  # os.pipe returns two file descriptors.
+    tmpf = tempfile.NamedTemporaryFile(mode='w+b', buffering=0, delete=False)
 
     try:
         # Flush the C-level buffer of stdout before redirecting.  This should make sure that only the desired data is captured.
         c_fflush()
         # Redirect stdout to your pipe.
-        os.dup2(pipe_write_end, stdout_file_descriptor)
+        os.dup2(tmpf.fileno(), stdout_file_descriptor)
         yield  # wait for input
     finally:
         # Flush the C-level buffer of stdout before returning things to normal.  This seems to be mainly needed on Windows because it looks like Windows changes the buffering policy to be fully buffered when redirecting stdout.
         c_fflush()
         # Redirect stdout back to the original file descriptor.
         os.dup2(original_stdout_file_descriptor_copy, stdout_file_descriptor)
-        # Close the write end of the pipe to allow reading.
-        os.close(pipe_write_end)
-        # Read what was written to the pipe and pass it to the binary stream for use outside this function.
-        pipe_reader = os.fdopen(pipe_read_end, 'rb')
-        binary_stream.write(pipe_reader.read())
-        # Close the reader, also closes the pipe_read_end file descriptor.
-        pipe_reader.close()
+        # Open the temp file in read mode
+        tmpf.close()
+        tmpf = open(tmpf.name, 'rb', 0)
+        binary_stream.write(tmpf.read())
         # Close the remaining open file descriptor.
         os.close(original_stdout_file_descriptor_copy)
+        # Close and remove the temp file
+        tmpf.close()
+        os.remove(tmpf.name)
 
 
 def get_host_components(host):

--- a/addons/io_hubs_addon/components/utils.py
+++ b/addons/io_hubs_addon/components/utils.py
@@ -186,6 +186,8 @@ if platform.system() == "Windows":
             os.dup2(original_stdout_file_descriptor_copy, stdout_file_descriptor)
             # Truncate file to the written amount of bytes
             __stack_tmp_file.truncate()
+            #  Move the file pointer to the start of the file
+            __stack_tmp_file.seek(0)
             # Write back to the input stream
             binary_stream.write(__stack_tmp_file.read())
             # Close the remaining open file descriptor.
@@ -327,7 +329,7 @@ if platform.system() == "Windows":
 def register():
     if platform.system() == "Windows":
         global __stack_tmp_file
-        __stack_tmp_file = tempfile.NamedTemporaryFile(mode='r+b', buffering=0, delete=False, dir=bpy.app.tempdir)
+        __stack_tmp_file = tempfile.NamedTemporaryFile(mode='w+b', buffering=0, delete=False, dir=bpy.app.tempdir)
 
 
 def unregister():


### PR DESCRIPTION
We are interfacing with the C level stdout str to be able to read the ouput of `bpy.context.window_manager.print_undo_steps()` to find if an undo happened. For some reason that I don't really understand piping that stream seems to misbehave in Windows when the buffer is over 4k. Ideally we should find the reason for this but in the meantime I've workarounded this by replacing piping with a temp file. This is Windows only as undo steps are configurable (and some people might have quite high numbers) and we should avoid file I/O.

An alternative to this would be to access the `WindowManager`native instance through a ctype wrapper and get the `undo_stack` from there: https://github.com/blender/blender/blob/master/source/blender/makesdna/DNA_windowmanager_types.h but it will make us dependent on the internal `WindowManager` struct update which might be tricky to maintain (python mirror struct needs to be aligned with the actual struct members). For now, unless we can find out the reason for the behavior above, I think this will suffice.