### PR TITLE
Add a dynamic option for audio zones to be movable

### DIFF
--- a/addons/io_hubs_addon/components/definitions/audio_zone.py
+++ b/addons/io_hubs_addon/components/definitions/audio_zone.py
@@ -28,6 +28,11 @@ class AudioZone(HubsComponent):
         description="The zone audio parameters affect the sources outside the zone when the listener is inside",
         default=True)
 
+    dynamic: BoolProperty(
+        name="Dynamic",
+        description="Wether or not this audio-zone will be movable",
+        default=False)
+
     @classmethod
     def update_gizmo(cls, ob, bone, target, gizmo):
         if bone:

--- a/addons/io_hubs_addon/components/definitions/audio_zone.py
+++ b/addons/io_hubs_addon/components/definitions/audio_zone.py
@@ -30,7 +30,7 @@ class AudioZone(HubsComponent):
 
     dynamic: BoolProperty(
         name="Dynamic",
-        description="Wether or not this audio-zone will be movable",
+        description="Whether or not this audio-zone will be movable",
         default=False)
 
     @classmethod

--- a/tests/test/test_export.js
+++ b/tests/test/test_export.js
@@ -679,7 +679,8 @@ describe('Exporter', function () {
         const ext = node.extensions['MOZ_hubs_components'];
         assert.deepStrictEqual(ext["audio-zone"], {
           "inOut": true,
-          "outIn": true
+          "outIn": true,
+          "dynamic": false
         });
         assert.deepStrictEqual(ext["audio-params"], {
           "audioType": "pannernode",


### PR DESCRIPTION
*Note*: To land after the new loader is active in the client.

This PR adds support for dynamic audio-zones.