### PR TITLE
Migrate Y/Z axis swap and bump version

### DIFF
--- a/addons/io_hubs_addon/components/definitions/particle_emitter.py
+++ b/addons/io_hubs_addon/components/definitions/particle_emitter.py
@@ -132,11 +132,6 @@ class ParticleEmitter(HubsComponent):
             endVelocity = Vector((endVelocity.x, endVelocity.z, endVelocity.y))
             self.endVelocity = endVelocity
 
-            if migration_type != MigrationType.GLOBAL or is_linked(ob) or type(ob) == bpy.types.Armature:
-                host_reference = get_host_reference_message(panel_type, host, ob=ob)
-                migration_report.append(
-                    f"Warning: The Particle Emitter component's Y and Z on startVelocity and endVelocity on the {panel_type.value} {host_reference} may not have migrated correctly")
-
         return migration_occurred
 
     @classmethod

--- a/tests/test/test_export.js
+++ b/tests/test/test_export.js
@@ -350,13 +350,13 @@ describe('Exporter', function () {
             "velocityCurve":"linear",
             "startVelocity":{
               "x":0,
-              "y":0.5,
-              "z":0
+              "y":0,
+              "z":0.5
             },
             "endVelocity":{
               "x":0,
-              "y":0.5,
-              "z":0
+              "y":0,
+              "z":0.5
             },
             "angularVelocity":0
           }


### PR DESCRIPTION
Bump particle-emitter component version to 1.1.0 and add a Y/Z axis migration to be consistent with the new swapping