### PR TITLE
Add Alpha Cutoff property on Image component

### DIFF
--- a/addons/io_hubs_addon/components/definitions/image.py
+++ b/addons/io_hubs_addon/components/definitions/image.py
@@ -32,7 +32,7 @@ class Image(HubsComponent):
         description="Transparency Mode",
         items=TRANSPARENCY_MODE,
         default="opaque")
-    
+
     alphaCutoff: FloatProperty(
         name="Alpha Cutoff",
         description="Pixels with alpha values lower than this will be transparent on Binary transparency mode",

--- a/addons/io_hubs_addon/components/definitions/image.py
+++ b/addons/io_hubs_addon/components/definitions/image.py
@@ -1,6 +1,6 @@
 from ..models import image
 from ..gizmos import CustomModelGizmo
-from bpy.props import EnumProperty, StringProperty, BoolProperty
+from bpy.props import EnumProperty, FloatProperty, StringProperty, BoolProperty
 from ..hubs_component import HubsComponent
 from ..types import Category, PanelType, NodeType
 from ..consts import PROJECTION_MODE, TRANSPARENCY_MODE
@@ -32,6 +32,11 @@ class Image(HubsComponent):
         description="Transparency Mode",
         items=TRANSPARENCY_MODE,
         default="opaque")
+    
+    alphaCutoff: FloatProperty(
+        name="Alpha Cutoff",
+        description="Pixels with alpha values lower than this will be transparent on Binary transparency mode",
+        default=0.5)
 
     projection: EnumProperty(
         name="Projection",


### PR DESCRIPTION
Added the missing Alpha Cutoff property, which is necessary for the mask mode to function properly. Without this property, all pixels become opaque.

Related line on Hubs is here: https://github.com/mozilla/hubs/blob/7fb2d12fa2f6be1572c695de4c73792397b175c8/src/components/media-image.js#L147

Blender:
![image](https://user-images.githubusercontent.com/882466/225376026-995249d6-134a-45cc-b6c5-7860fb48c57f.png)

On Spoke:
![image](https://user-images.githubusercontent.com/882466/225374525-50ebfb18-217f-4509-81e8-41fc592612a7.png)
