### PR TITLE
Align light defaults with Spoke's

### DIFF
--- a/addons/io_hubs_addon/components/definitions/directional_light.py
+++ b/addons/io_hubs_addon/components/definitions/directional_light.py
@@ -38,7 +38,7 @@ class DirectionalLight(HubsComponent):
 
     shadowBias: FloatProperty(name="Shadow Bias",
                               description="Shadow Bias",
-                              default=1.0)
+                              default=0.0)
 
     shadowRadius: FloatProperty(name="Shadow Radius",
                                 description="Shadow Radius",

--- a/addons/io_hubs_addon/components/definitions/point_light.py
+++ b/addons/io_hubs_addon/components/definitions/point_light.py
@@ -31,11 +31,11 @@ class PointLight(HubsComponent):
 
     range: FloatProperty(name="Range",
                          description="Range",
-                         default=1.0)
+                         default=0.0)
 
     decay: FloatProperty(name="Decay",
                          description="Decay",
-                         default=1.0)
+                         default=2.0)
 
     castShadow: BoolProperty(
         name="Cast Shadow", description="Cast Shadow", default=True)
@@ -47,7 +47,7 @@ class PointLight(HubsComponent):
 
     shadowBias: FloatProperty(name="Shadow Bias",
                               description="Shadow Bias",
-                              default=1.0)
+                              default=0.0)
 
     shadowRadius: FloatProperty(name="Shadow Radius",
                                 description="Shadow Radius",

--- a/addons/io_hubs_addon/components/definitions/spot_light.py
+++ b/addons/io_hubs_addon/components/definitions/spot_light.py
@@ -32,7 +32,7 @@ class SpotLight(HubsComponent):
 
     range: FloatProperty(name="Range",
                          description="Range",
-                         default=1.0)
+                         default=0.0)
 
     decay: FloatProperty(name="Decay",
                          description="Decay",
@@ -56,7 +56,7 @@ class SpotLight(HubsComponent):
 
     decay: FloatProperty(name="Decay",
                          description="Decay",
-                         default=1.0)
+                         default=2.0)
 
     castShadow: BoolProperty(
         name="Cast Shadow", description="Cast Shadow", default=True)
@@ -68,7 +68,7 @@ class SpotLight(HubsComponent):
 
     shadowBias: FloatProperty(name="Shadow Bias",
                               description="Shadow Bias",
-                              default=1.0)
+                              default=0.0)
 
     shadowRadius: FloatProperty(name="Shadow Radius",
                                 description="Shadow Radius",


### PR DESCRIPTION
The current defaults are not aligned with Spoke's and also don't output working lights.