### PR TITLE
Fix encode call for Blender 3.5

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Python Linter
         uses: weibullguy/python-lint-plus@v1.9.0
         with:
-          python-root-list: 'addons'
+          python-root-list: "addons"
           use-black: false
           use-yapf: false
           use-isort: false
@@ -31,28 +31,28 @@ jobs:
           use-rstcheck: false
           use-check-manifest: false
           use-pyroma: false
-          extra-black-options: ''
-          extra-yapf-options: ''
-          extra-isort-options: ''
-          extra-docformatter-options: ''
+          extra-black-options: ""
+          extra-yapf-options: ""
+          extra-isort-options: ""
+          extra-docformatter-options: ""
           # This should work with **/models but it doesn't
-          extra-pycodestyle-options: '--exclude=models --ignore=E501,W504'
-          extra-pydocstyle-options: ''
-          extra-mypy-options: ''
-          extra-pylint-options: ''
-          extra-flake8-options: ''
-          extra-mccabe-options: ''
-          extra-radon-options: ''
-          extra-rstcheck-options: ''
-          extra-manifest-options: ''
-          extra-pyroma-options: ''
+          extra-pycodestyle-options: "--exclude=models --ignore=E501,W504"
+          extra-pydocstyle-options: ""
+          extra-mypy-options: ""
+          extra-pylint-options: ""
+          extra-flake8-options: ""
+          extra-mccabe-options: ""
+          extra-radon-options: ""
+          extra-rstcheck-options: ""
+          extra-manifest-options: ""
+          extra-pyroma-options: ""
 
   test:
     needs: lint
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ["3.4.0", "3.3.1", "2.93.9"]
+        version: ["3.5.0", "3.4.0", "3.3.1", "2.93.9"]
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3

--- a/addons/io_hubs_addon/io/utils.py
+++ b/addons/io_hubs_addon/io/utils.py
@@ -31,10 +31,13 @@ class HubsExportImage(gltf2_blender_image.ExportImage):
             export_image.fill_image(image, dst_chan=chan, src_chan=chan)
         return export_image
 
-    def encode(self, mime_type: Optional[str]) -> Union[Tuple[bytes, bool], bytes]:
+    def encode(self, mime_type: Optional[str], export_settings) -> Union[Tuple[bytes, bool], bytes]:
         if mime_type == "image/vnd.radiance":
             return self.encode_from_image_hdr(self.blender_image())
-        return super().encode(mime_type)
+        if bpy.app.version < (3, 5, 0):
+            return super().encode(mime_type)
+        else:
+            return super().encode(mime_type, export_settings)
 
     # TODO this should allow conversion from other HDR formats (namely EXR),
     # in memory images, and combining separate channels like SDR images
@@ -68,7 +71,7 @@ def gather_image(blender_image, export_settings):
     else:
         mime_type = "image/jpeg"
 
-    data = HubsExportImage.from_blender_image(blender_image).encode(mime_type)
+    data = HubsExportImage.from_blender_image(blender_image).encode(mime_type, export_settings)
 
     if type(data) == tuple:
         data = data[0]


### PR DESCRIPTION
`ExportImage.encode` has changed it's signature in the Blender 3.5 glTF exporter. This PR adds 3.5.0 testing support and fixes the encoding issue.