### PR TITLE
Return FINISHED instead of RUNNING_MODAL for popups

### DIFF
--- a/addons/io_hubs_addon/components/definitions/reflection_probe.py
+++ b/addons/io_hubs_addon/components/definitions/reflection_probe.py
@@ -700,7 +700,7 @@ class SelectMismatchedReflectionProbes(Operator):
                 op.mismatched_probe_indexes = ''
 
         bpy.context.window_manager.popup_menu(draw)
-        return {'RUNNING_MODAL'}
+        return {'FINISHED'}
 
 
 class ReflectionProbe(HubsComponent):

--- a/addons/io_hubs_addon/components/operators.py
+++ b/addons/io_hubs_addon/components/operators.py
@@ -166,7 +166,7 @@ class AddHubsComponent(Operator):
 
         bpy.context.window_manager.popup_menu(draw)
 
-        return {'RUNNING_MODAL'}
+        return {'FINISHED'}
 
 
 class RemoveHubsComponent(Operator):


### PR DESCRIPTION
Fixes https://github.com/MozillaReality/hubs-blender-exporter/issues/180

This PR changes the return type when we show popups from `RUNNING_MODAL` to `FINISHED`. That fixes the issue as explained here: https://projects.blender.org/blender/blender/issues/106368#issuecomment-917778