### PR TITLE
Improve image component alpha cutoff

### DIFF
--- a/addons/io_hubs_addon/components/definitions/image.py
+++ b/addons/io_hubs_addon/components/definitions/image.py
@@ -36,7 +36,9 @@ class Image(HubsComponent):
     alphaCutoff: FloatProperty(
         name="Alpha Cutoff",
         description="Pixels with alpha values lower than this will be transparent on Binary transparency mode",
-        default=0.5)
+        default=0.5,
+        min=0.0,
+        max=1.0)
 
     projection: EnumProperty(
         name="Projection",

--- a/addons/io_hubs_addon/components/definitions/image.py
+++ b/addons/io_hubs_addon/components/definitions/image.py
@@ -46,6 +46,14 @@ class Image(HubsComponent):
         items=PROJECTION_MODE,
         default="flat")
 
+    def draw(self, context, layout, panel_type):
+        layout.prop(self, "src")
+        layout.prop(self, "controls")
+        layout.prop(self, "alphaMode")
+        if self.alphaMode == "mask":
+            layout.prop(self, "alphaCutoff")
+        layout.prop(self, "projection")
+
     def migrate(self, migration_type, panel_type, instance_version, host, migration_report, ob=None):
         migration_occurred = False
         if instance_version < (1, 0, 0):


### PR DESCRIPTION
Limits the minimum and maximum values to between 0-1.
Hides the alpha cutoff property in the UI when the transparency mode isn't set to binary/mask.

Note: The alpha cutoff property still exports regardless of the transparency mode, but would it be better not to export it when it isn't used?