### PR TITLE
Disable operators for linked objects

### DIFF
--- a/addons/io_hubs_addon/components/definitions/loop_animation.py
+++ b/addons/io_hubs_addon/components/definitions/loop_animation.py
@@ -402,11 +402,14 @@ class RemoveTrackOperator(Operator):
 
     @classmethod
     def poll(cls, context):
-        panel_type = PanelType(context.panel.bl_context)
-        ob = context.object
-        host = ob if panel_type == PanelType.OBJECT else context.active_bone
+        if hasattr(context, "panel"):
+            panel_type = PanelType(context.panel.bl_context)
+            ob = context.object
+            host = ob if panel_type == PanelType.OBJECT else context.active_bone
 
-        return host.hubs_component_loop_animation.active_track_key != -1
+            return host.hubs_component_loop_animation.active_track_key != -1
+
+        return True
 
     def execute(self, context):
         panel_type = PanelType(context.panel.bl_context)

--- a/addons/io_hubs_addon/components/operators.py
+++ b/addons/io_hubs_addon/components/operators.py
@@ -22,6 +22,26 @@ class AddHubsComponent(Operator):
     panel_type: StringProperty(name="panel_type")
     component_name: StringProperty(name="component_name")
 
+    @classmethod
+    def poll(cls, context):
+        if hasattr(context, "panel"):
+            panel = getattr(context, 'panel')
+            panel_type = PanelType(panel.bl_context)
+            if panel_type == PanelType.SCENE:
+                if is_linked(context.scene):
+                    cls.poll_message_set("Disabled: Cannot add components to linked scenes")
+                    return False
+            elif panel_type == PanelType.OBJECT:
+                if is_linked(context.active_object):
+                    cls.poll_message_set("Disabled: Cannot add components to linked objects")
+                    return False
+            elif panel_type == PanelType.MATERIAL:
+                if is_linked(context.active_object.active_material):
+                    cls.poll_message_set("Disabled: Cannot add components to linked materials")
+                    return False
+
+        return True
+
     def execute(self, context):
         if self.component_name == '':
             return
@@ -178,6 +198,26 @@ class RemoveHubsComponent(Operator):
 
     panel_type: StringProperty(name="panel_type")
     component_name: StringProperty(name="component_name")
+
+    @classmethod
+    def poll(cls, context):
+        if hasattr(context, "panel"):
+            panel = getattr(context, 'panel')
+            panel_type = PanelType(panel.bl_context)
+            if panel_type == PanelType.SCENE:
+                if is_linked(context.scene):
+                    cls.poll_message_set("Disabled: Cannot remove components from linked scenes")
+                    return False
+            elif panel_type == PanelType.OBJECT:
+                if is_linked(context.active_object):
+                    cls.poll_message_set("Disabled: Cannot remove components from linked objects")
+                    return False
+            elif panel_type == PanelType.MATERIAL:
+                if is_linked(context.active_object.active_material):
+                    cls.poll_message_set("Disabled: Cannot remove components from linked materials")
+                    return False
+
+        return True
 
     def execute(self, context):
         if self.component_name == '':
@@ -449,9 +489,12 @@ class CopyHubsComponent(Operator):
 
     @classmethod
     def poll(cls, context):
-        panel = getattr(context, 'panel')
-        panel_type = PanelType(panel.bl_context)
-        return panel_type != PanelType.SCENE
+        if hasattr(context, "panel"):
+            panel = getattr(context, 'panel')
+            panel_type = PanelType(panel.bl_context)
+            return panel_type != PanelType.SCENE
+
+        return True
 
     def get_selected_bones(self, context):
         selected_bones = context.selected_pose_bones if context.mode == "POSE" else context.selected_editable_bones
@@ -540,11 +583,12 @@ class OpenImage(Operator):
 
     @ classmethod
     def poll(cls, context):
-        ob = getattr(context, 'host')
-        if is_linked(ob):
-            if bpy.app.version >= (3, 0, 0):
-                cls.poll_message_set(f"{cls.disabled_message}.")
-            return False
+        if hasattr(context, "host"):
+            ob = getattr(context, 'host')
+            if is_linked(ob):
+                if bpy.app.version >= (3, 0, 0):
+                    cls.poll_message_set(f"{cls.disabled_message}.")
+                return False
 
         return True
 

--- a/addons/io_hubs_addon/components/ui.py
+++ b/addons/io_hubs_addon/components/ui.py
@@ -2,7 +2,7 @@ import bpy
 from bpy.props import StringProperty
 from .types import PanelType
 from .components_registry import get_component_by_name, get_components_registry
-from .utils import get_object_source, dash_to_title
+from .utils import get_object_source, dash_to_title, is_linked
 
 
 def draw_component_global(panel, context):
@@ -61,6 +61,7 @@ def draw_component(panel, context, obj, row, component_item):
             copy_component_operator.panel_type = panel.bl_context
 
         if not (component_class.is_dep_only() or component_item.isDependency):
+            top_row.context_pointer_set("panel", panel)
             remove_component_operator = top_row.operator(
                 "wm.remove_hubs_component",
                 text="",
@@ -69,14 +70,17 @@ def draw_component(panel, context, obj, row, component_item):
             remove_component_operator.component_name = component_name
             remove_component_operator.panel_type = panel.bl_context
 
+        body_col = col.column()
+        body_col.enabled = not is_linked(obj)
         if component_item.expanded:
-            component.draw(context, col, panel)
+            component.draw(context, body_col, panel)
 
     else:
         col = row.box().column()
         top_row = col.row()
         top_row.label(
             text=f"Unknown component '{component_name}'", icon="ERROR")
+        top_row.context_pointer_set("panel", panel)
         remove_component_operator = top_row.operator(
             "wm.remove_hubs_component",
             text="",
@@ -94,6 +98,7 @@ def draw_components_list(panel, context):
     if not obj:
         return
 
+    layout.context_pointer_set("panel", panel)
     add_component_operator = layout.operator(
         "wm.add_hubs_component",
         text="Add Component",


### PR DESCRIPTION
Fixes https://github.com/MozillaReality/hubs-blender-exporter/issues/165

This PR disables operators for linked objects and shows an error message in the tooltip.

The whole component panel is disables for objets, scenes and materials is the component is on a linked object.

The copy operator is always enabled except for scene components.