### PR TITLE
Fix for gtlf exporter python library path changes

### DIFF
--- a/addons/io_hubs_addon/io/utils.py
+++ b/addons/io_hubs_addon/io/utils.py
@@ -1,14 +1,14 @@
 import os
 import bpy
 from io_scene_gltf2.blender.com import gltf2_blender_extras
-from io_scene_gltf2.blender.exp import gltf2_blender_gather_materials, gltf2_blender_gather_nodes, gltf2_blender_gather_joints
-from io_scene_gltf2.blender.exp import gltf2_blender_gather_texture_info, gltf2_blender_export_keys
+from io_scene_gltf2.blender.exp import gltf2_blender_gather_nodes, gltf2_blender_gather_joints
+from io_scene_gltf2.blender.exp.material import gltf2_blender_gather_materials, gltf2_blender_gather_texture_info
+from io_scene_gltf2.blender.exp.material.extensions import gltf2_blender_image
 from io_scene_gltf2.blender.exp.gltf2_blender_gather_cache import cached
 from io_scene_gltf2.io.com import gltf2_io_extensions
 from io_scene_gltf2.io.com import gltf2_io
 from io_scene_gltf2.io.exp import gltf2_io_binary_data
 from io_scene_gltf2.io.exp import gltf2_io_image_data
-from io_scene_gltf2.blender.exp import gltf2_blender_image
 from typing import Optional, Tuple, Union
 from ..nodes.lightmap import MozLightmapNode
 
@@ -76,7 +76,7 @@ def gather_image(blender_image, export_settings):
     if type(data) == tuple:
         data = data[0]
 
-    if export_settings[gltf2_blender_export_keys.FORMAT] == 'GLTF_SEPARATE':
+    if export_settings['gltf_format'] == 'GLTF_SEPARATE':
         uri = HubsImageData(data=data, mime_type=mime_type, name=name)
         buffer_view = None
     else:


### PR DESCRIPTION
Addresses https://github.com/MozillaReality/hubs-blender-exporter/issues/225 in Blender 3.6 by fixing some of the import paths. I'm not sure of the implications for previous versions of Blender though or if there are any other compatibility issues, so I will keep this in draft for now.