### PR TITLE
Revert some poll changes in commit "Disable operators for linked hosts fixes."

### DIFF
--- a/addons/io_hubs_addon/components/definitions/loop_animation.py
+++ b/addons/io_hubs_addon/components/definitions/loop_animation.py
@@ -485,7 +485,7 @@ class RemoveTrackOperator(Operator):
 
             return host.hubs_component_loop_animation.active_track_key != -1
 
-        return False
+        return True
 
     def execute(self, context):
         panel_type = PanelType(context.panel.bl_context)

--- a/addons/io_hubs_addon/components/operators.py
+++ b/addons/io_hubs_addon/components/operators.py
@@ -22,11 +22,8 @@ class AddHubsComponent(Operator):
     panel_type: StringProperty(name="panel_type")
     component_name: StringProperty(name="component_name")
 
-    is_execute_poll = False
-
     @classmethod
     def poll(cls, context):
-        # main button poll
         if hasattr(context, "panel"):
             panel = getattr(context, 'panel')
             panel_type = PanelType(panel.bl_context)
@@ -51,15 +48,7 @@ class AddHubsComponent(Operator):
                         cls.poll_message_set("Cannot add components to linked bones")
                     return False
 
-            return True
-
-        # menu item poll
-        elif cls.is_execute_poll:
-            cls.is_execute_poll = False
-            return True
-
-        else:
-            return False
+        return True
 
     def execute(self, context):
         if self.component_name == '':
@@ -206,7 +195,6 @@ class AddHubsComponent(Operator):
                     text="No components available for this object type")
 
         bpy.context.window_manager.popup_menu(draw)
-        AddHubsComponent.is_execute_poll = True
 
         return {'FINISHED'}
 
@@ -245,9 +233,7 @@ class RemoveHubsComponent(Operator):
                         cls.poll_message_set("Cannot add components to linked bones")
                     return False
 
-            return True
-
-        return False
+        return True
 
     def execute(self, context):
         if self.component_name == '':
@@ -529,7 +515,7 @@ class CopyHubsComponent(Operator):
             panel_type = PanelType(panel.bl_context)
             return panel_type != PanelType.SCENE
 
-        return False
+        return True
 
     def get_selected_bones(self, context):
         selected_bones = context.selected_pose_bones if context.mode == "POSE" else context.selected_editable_bones
@@ -626,9 +612,7 @@ class OpenImage(Operator):
                     cls.poll_message_set(f"{cls.disabled_message}.")
                 return False
 
-            return True
-
-        return False
+        return True
 
     def draw(self, context):
         layout = self.layout


### PR DESCRIPTION
Revert the changes to the AddHubsComponent poll and the poll default return values from commit fa0f4761b8421b1b20336634704b4223b334bda9

The changes to the AddHubsComponent poll caused an intermittent bug when adding components where the component wouldn't be added when selected because of a poll failure. Things like adding an object and then trying to add a component would trigger this bug. For some reason, adding an object seems to cause problems with passing the context pointer.

The changes to the poll default return values were because I thought it made more sense to return false when the poll was in an invalid state because the context pointer wasn't set, but given the above bug, reverting to returning true seems safer.