### PR TITLE
Improve the file loading guard on the undo stack handler.

### DIFF
--- a/addons/io_hubs_addon/components/handlers.py
+++ b/addons/io_hubs_addon/components/handlers.py
@@ -239,11 +239,11 @@ def undo_stack_handler(dummy, depsgraph):
     global object_data_switched
 
     # Return if Blender isn't in a fully loaded state. (Prevents Blender crashing)
-    if file_loading and not bpy.context.space_data:
-        file_loading = False
-        return
+    if file_loading:
+        if not bpy.context.space_data:
+            return
 
-    file_loading = False
+        file_loading = False
 
     # Get a representation of the undo stack.
     binary_stream = io.BytesIO()


### PR DESCRIPTION
Use a more flexible approach so that the guard will be certain to remain in place until the blend file has loaded to a usable state. This fixes #239.