### PR TITLE
Tests updates

### DIFF
--- a/tests/test/utils.js
+++ b/tests/test/utils.js
@@ -6,7 +6,7 @@ const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12
 
 function blenderFileToGltf(blenderVersion, blenderPath, outDirName, done, options = '') {
   const { exec } = require('child_process');
-  const cmd = `${blenderVersion} -b --factory-startup --addons io_hubs_addon -noaudio ${blenderPath} --python export_gltf.py -- ${outDirName} ${options}`;
+  const cmd = `BLENDER_USER_SCRIPTS=${path.resolve("../")} ${blenderVersion} -b --factory-startup --addons io_hubs_addon -noaudio ${blenderPath} --python export_gltf.py -- ${outDirName} ${options}`;
   var prc = exec(cmd, (error, stdout, stderr) => {
     //if (stderr) process.stderr.write(stderr);
 
@@ -21,7 +21,7 @@ function blenderFileToGltf(blenderVersion, blenderPath, outDirName, done, option
 
 function blenderRoundtripGltf(blenderVersion, gltfPath, outDirName, done, options = '') {
   const { exec } = require('child_process');
-  const cmd = `${blenderVersion} -b --factory-startup --addons io_hubs_addon -noaudio --python roundtrip_gltf.py -- ${gltfPath} ${outDirName} ${options}`;
+  const cmd = `BLENDER_USER_SCRIPTS=${path.resolve("../")} ${blenderVersion} -b --factory-startup --addons io_hubs_addon -noaudio --python roundtrip_gltf.py -- ${gltfPath} ${outDirName} ${options}`;
   var prc = exec(cmd, (error, stdout, stderr) => {
     //if (stderr) process.stderr.write(stderr);
 


### PR DESCRIPTION
Tests are failing for me on 3.6.0, it seems that the culprit is the way we enable the add-on for instrumentation Blender. I've replaced that with the  BLENDER_USER_SCRIPTS command line argument that seems to work more reliably across versions.

So this fixed the test locally but somehow they still fail here, not sure why they started to suddenly fail though...