### PR TITLE
Make export camera/lights default False and change Export Lights -> Punctual Lights

### DIFF
--- a/addons/io_hubs_addon/debugger.py
+++ b/addons/io_hubs_addon/debugger.py
@@ -575,10 +575,10 @@ class HubsSceneDebuggerRoomCreatePrefs(bpy.types.PropertyGroup):
 
 
 class HubsSceneDebuggerRoomExportPrefs(bpy.types.PropertyGroup):
-    export_cameras: bpy.props.BoolProperty(name="Export Cameras", default=True,
+    export_cameras: bpy.props.BoolProperty(name="Export Cameras", default=False,
                                            description="Export cameras", options=set())
     export_lights: bpy.props.BoolProperty(
-        name="Export Lights", default=True,
+        name="Punctual Lights", default=False,
         description="Punctual Lights, Export directional, point, and spot lights. Uses \"KHR_lights_punctual\" glTF extension",
         options=set())
     use_selection: bpy.props.BoolProperty(name="Selection Only", default=False,


### PR DESCRIPTION
After some feedback it seems to make more sense to make export camera/lights false by default.

Also this PR changes the Export Lights flag name to Punctual Lights to match the Blender exporter name.