### PR TITLE
Scene Debugger: Allow spawning objects when not signed in.

### DIFF
--- a/addons/io_hubs_addon/hubs_session.py
+++ b/addons/io_hubs_addon/hubs_session.py
@@ -143,7 +143,7 @@ class HubsSession:
             self._room_params = {k: v for k, v in params.items() if k != "hub_id"}
 
             params = self._web_driver.execute_script(JS_STATE_UPDATE)
-            self._user_logged_in = params["signedIn"]
+            self._user_logged_in = params["signedIn"] or not "debugLocalScene" in self._room_params
             self._user_in_room = params["entered"]
             self._room_name = params["roomName"]
 


### PR DESCRIPTION
This restores the ability to spawn objects when not signed in and not using debugLocalScene that was accidentally removed in commit 83778e7b96d7b6ec6fda91cda8dd9dd37b93deb6