### PR TITLE
Fixed a bug when loading images using relative paths [Deprecated]

### DIFF
--- a/addons/io_hubs_addon/components/definitions/fog.py
+++ b/addons/io_hubs_addon/components/definitions/fog.py
@@ -13,6 +13,7 @@ class Fog(HubsComponent):
         'icon': 'MOD_OCEAN',
         'version': (1, 0, 0)
     }
+    
     def draw(self, context, layout, panel):
         '''Draw method to be called by the panel. The base class method will print all the component properties'''
         layout.prop(data=self, property="type")

--- a/addons/io_hubs_addon/components/definitions/fog.py
+++ b/addons/io_hubs_addon/components/definitions/fog.py
@@ -13,7 +13,7 @@ class Fog(HubsComponent):
         'icon': 'MOD_OCEAN',
         'version': (1, 0, 0)
     }
-    
+
     def draw(self, context, layout, panel):
         '''Draw method to be called by the panel. The base class method will print all the component properties'''
         layout.prop(data=self, property="type")
@@ -33,16 +33,11 @@ class Fog(HubsComponent):
                 default="linear")
 
     color: FloatVectorProperty(name="Color",
-                        subtype='COLOR_GAMMA',
-                        default=(1.0, 1.0, 1.0, 1.0),
-                        size=4,
-                        min=0,
-                        max=1,
-                        subtype='COLOR_GAMMA',
-                        default=(1.0, 1.0, 1.0, 1.0),
-                        size=4,
-                        min=0,
-                        max=1)
+                            subtype='COLOR_GAMMA',
+                            default=(1.0, 1.0, 1.0, 1.0),
+                            size=4,
+                            min=0,
+                            max=1)
     # TODO Make these properties to be displayed dynamically based on the fog type #BlenderDiplom: Done
     near: FloatProperty(
         name="Near", description="Fog Near Distance (linear only)", default=1.0) 

--- a/addons/io_hubs_addon/components/definitions/fog.py
+++ b/addons/io_hubs_addon/components/definitions/fog.py
@@ -27,19 +27,22 @@ class Fog(HubsComponent):
         name="type",
         description="Fog Type",
         items=[("linear", "Linear fog", "Fog effect will increase linearly with distance"),
-            ("exponential", "Exponential fog",
+                ("exponential", "Exponential fog",
                 "Fog effect will increase exponentially with distance")],
-        default="linear")
+                default="linear")
 
     color: FloatVectorProperty(name="Color",
-                            subtype='COLOR_GAMMA',
-                            default=(1.0, 1.0, 1.0, 1.0),
-                            size=4,
-                            min=0,
-                            max=1)
-
-    # TODO Make these properties to be displayed dynamically based on the fog type
-
+                        subtype='COLOR_GAMMA',
+                        default=(1.0, 1.0, 1.0, 1.0),
+                        size=4,
+                        min=0,
+                        max=1,
+                        subtype='COLOR_GAMMA',
+                        default=(1.0, 1.0, 1.0, 1.0),
+                        size=4,
+                        min=0,
+                        max=1)
+    # TODO Make these properties to be displayed dynamically based on the fog type #BlenderDiplom: Done
     near: FloatProperty(
         name="Near", description="Fog Near Distance (linear only)", default=1.0) 
 

--- a/addons/io_hubs_addon/components/definitions/fog.py
+++ b/addons/io_hubs_addon/components/definitions/fog.py
@@ -13,28 +13,38 @@ class Fog(HubsComponent):
         'icon': 'MOD_OCEAN',
         'version': (1, 0, 0)
     }
+    def draw(self, context, layout, panel):
+        '''Draw method to be called by the panel. The base class method will print all the component properties'''
+        layout.prop(data=self, property="type")
+        print("Type:", self.type)
+        if self.type == "linear":
+            layout.prop(data=self, property="near")
+            layout.prop(data=self, property="far")
+        else:
+            layout.prop(data=self, property="density")
 
     type: EnumProperty(
         name="type",
         description="Fog Type",
         items=[("linear", "Linear fog", "Fog effect will increase linearly with distance"),
-               ("exponential", "Exponential fog",
+            ("exponential", "Exponential fog",
                 "Fog effect will increase exponentially with distance")],
         default="linear")
 
     color: FloatVectorProperty(name="Color",
-                               subtype='COLOR_GAMMA',
-                               default=(1.0, 1.0, 1.0, 1.0),
-                               size=4,
-                               min=0,
-                               max=1)
+                            subtype='COLOR_GAMMA',
+                            default=(1.0, 1.0, 1.0, 1.0),
+                            size=4,
+                            min=0,
+                            max=1)
 
     # TODO Make these properties to be displayed dynamically based on the fog type
+
     near: FloatProperty(
-        name="Near", description="Fog Near Distance (linear only)", default=1.0)
+        name="Near", description="Fog Near Distance (linear only)", default=1.0) 
 
     far: FloatProperty(
         name="Far", description="Fog Far Distance (linear only)", default=100.0)
-
+    
     density: FloatProperty(
         name="Density", description="Fog Density (exponential only)", default=0.00025)

--- a/addons/io_hubs_addon/components/operators.py
+++ b/addons/io_hubs_addon/components/operators.py
@@ -650,8 +650,9 @@ class OpenImage(Operator):
         old_img = self.hubs_component[self.target_property]
 
         # Load/Reload the first image and assign it to the target property, then load the rest of the images if they're not already loaded. This mimics Blender's default open files behavior.
+        filepath = os.path.join(self.directory, self.files[0].name)
         primary_img = bpy.data.images.load(
-            filepath=self.filepath, check_existing=True)
+            filepath=filepath, check_existing=True)
         primary_img.reload()
         self.hubs_component[self.target_property] = primary_img
 

--- a/addons/io_hubs_addon/components/operators.py
+++ b/addons/io_hubs_addon/components/operators.py
@@ -640,7 +640,11 @@ class OpenImage(Operator):
         layout.prop(self, "relative_path")
 
     def execute(self, context):
-        dirname = os.path.dirname(self.filepath)
+        #dirname = os.path.dirname(self.filepath) #fails if path selected in the Blender File View is relative (starts with //)
+        abs_dir = bpy.path.abspath(self.filepath) # converts relative paths to absolute ones eg //MyPath -> C:\MyPath
+        #or:
+        #abs_dir = self.filepath if not self.relative_path else bpy.path.abspath(self.filepath)
+        dirname = os.path.dirname(abs_dir)
 
         if not self.files[0].name:
             self.report({'INFO'}, "Open image cancelled.  No image selected.")


### PR DESCRIPTION
using the
class OpenImage(Operator)
fails when using the default 'relative_path' property (True).
We fixed that error and made the file browser start where the previous image was located. We also modified the dedfault location of the File Viewer to either:
a) Start where a file was selected the last time the File View was used or:
b) if an image had been previously assigned to the target_property, the File View will start with that image selected.
This is Blender's default behaviour

![grafik](https://github.com/MozillaReality/hubs-blender-exporter/assets/8123251/d5c62666-420b-415d-b70d-2a390c820be7)
It probably failed when selecting an image for a reflection probe as well and should be working everywhere now.