### PR TITLE
Fix python error when using the open image button on reflection probes.

### DIFF
--- a/addons/io_hubs_addon/components/definitions/reflection_probe.py
+++ b/addons/io_hubs_addon/components/definitions/reflection_probe.py
@@ -700,7 +700,7 @@ class ReflectionProbe(HubsComponent):
             sub_row = row.row(align=True)
             sub_row.enabled = False
             add_link_indicator(sub_row, self.envMapTexture)
-        row.context_pointer_set("hubs_component", self)
+        row.context_pointer_set("target", self)
         row.context_pointer_set("host", context.active_object)
         op = row.operator("image.hubs_open_reflection_probe_envmap", text='', icon='FILE_FOLDER')
         op.target_property = "envMapTexture"


### PR DESCRIPTION
This got missed when the operator was restructured for the scene publishing support.