### PR TITLE
Fix Open Image Relative Path failing - New Try

### DIFF
--- a/addons/io_hubs_addon/components/operators.py
+++ b/addons/io_hubs_addon/components/operators.py
@@ -642,7 +642,6 @@ class OpenImage(Operator):
     
     def execute(self, context):
         #dirname = os.path.dirname(self.filepath) #dirname fails if path selected in the Blender File View is relative (starts with //) on Windows
-        print("filepath:", self.filepath)
         if not self.files[0].name:
             self.report({'INFO'}, "Open image cancelled. No image selected.")
             return {'CANCELLED'}

--- a/addons/io_hubs_addon/components/operators.py
+++ b/addons/io_hubs_addon/components/operators.py
@@ -509,7 +509,7 @@ class ReportViewer(Operator):
 
 
 def split_and_prefix_report_messages(report_string):
-    return [f"{i+1:02d}   {message}" for i, message in enumerate(report_string.split("\n\n"))]
+    return [f"{i + 1:02d}   {message}" for i, message in enumerate(report_string.split("\n\n"))]
 
 
 class CopyHubsComponent(Operator):
@@ -635,13 +635,8 @@ class OpenImage(Operator):
                 return False
 
         return True
-    
-    def draw(self, context): #this def is obsolete, bc. target_property is hidden by default now and relative_path is displayed by default anyways
-        layout = self.layout 
-        layout.prop(self, "relative_path")
-    
+
     def execute(self, context):
-        #dirname = os.path.dirname(self.filepath) #dirname fails if path selected in the Blender File View is relative (starts with //) on Windows
         if not self.files[0].name:
             self.report({'INFO'}, "Open image cancelled. No image selected.")
             return {'CANCELLED'}
@@ -649,14 +644,14 @@ class OpenImage(Operator):
         old_img = getattr(self.target, self.target_property)
 
         # Load/Reload the first image and assign it to the target property, then load the rest of the images if they're not already loaded. This mimics Blender's default open files behavior.
-        primary_filepath = os.path.join(self.directory, self.files[0].name) #self.files is sorted alphabetically by Blender, self.files[0] is the 1. of the selection in alphabetical order
+        primary_filepath = os.path.join(self.directory, self.files[0].name)  # self.files is sorted alphabetically by Blender, self.files[0] is the 1. of the selection in alphabetical order
         primary_img = bpy.data.images.load(
             filepath=primary_filepath, check_existing=True)
         primary_img.reload()
         setattr(self.target, self.target_property, primary_img)
 
         for f in self.files[1:]:
-            bpy.data.images.load(filepath=os.path.join( #join works with both relative and absolute paths
+            bpy.data.images.load(filepath=os.path.join(
                 self.directory, f.name), check_existing=True)
 
         update_image_editors(old_img, primary_img)
@@ -665,11 +660,11 @@ class OpenImage(Operator):
 
     def invoke(self, context, event):
         self.target = context.target
-        
+
         last_image = getattr(self.target, self.target_property)
-        if type(last_image) == bpy.types.Image: #if the component has been assigned before, get its filepath
-            self.filepath = last_image.filepath #start the file browser at the location of the previous file
-        
+        if type(last_image) is bpy.types.Image:  # if the component has been assigned before, get its filepath
+            self.filepath = last_image.filepath  # start the file browser at the location of the previous file
+
         context.window_manager.fileselect_add(self)
         return {'RUNNING_MODAL'}
 


### PR DESCRIPTION
We cleaned up the chaos by creating a new branch. The behaviour should match the previous behaviour now, let's call it "intuitive". 
class OpenImage(Operator)
fails when using the default 'relative_path' property (True) on Windows. Python os.path.join on Windows does not recognize '//' to be the beginning of a directory and treats it like a filename.
We fixed that error and made the file browser start where the previous image was located. We also modified the dedfault location of the File Viewer to either:
a) Start where a file was selected the last time the File View was used or:
b) if an image had been previously assigned to the target_property, the File View will start with that image selected.
This is Blender's default behaviour
![grafik](https://github.com/MozillaReality/hubs-blender-exporter/assets/8123251/599417f7-6de6-4b28-8036-f46320062181)


It probably failed when selecting an image for a reflection probe as well and should be working everywhere now.