### PR TITLE
Fog Settings Only Display Relevant Parameters

### DIFF
--- a/addons/io_hubs_addon/components/definitions/fog.py
+++ b/addons/io_hubs_addon/components/definitions/fog.py
@@ -13,6 +13,16 @@ class Fog(HubsComponent):
         'icon': 'MOD_OCEAN',
         'version': (1, 0, 0)
     }
+    
+    def draw(self, context, layout, panel):
+        '''Draw method to be called by the panel. The base class method will print all the component properties'''
+        layout.prop(data=self, property="type")
+        print("Type:", self.type)
+        if self.type == "linear":
+            layout.prop(data=self, property="near")
+            layout.prop(data=self, property="far")
+        else:
+            layout.prop(data=self, property="density")
 
     type: EnumProperty(
         name="type",
@@ -29,7 +39,7 @@ class Fog(HubsComponent):
                                min=0,
                                max=1)
 
-    # TODO Make these properties to be displayed dynamically based on the fog type
+    # TODO Make these properties to be displayed dynamically based on the fog type, BlenderDiplom: Done
     near: FloatProperty(
         name="Near", description="Fog Near Distance (linear only)", default=1.0)
 

--- a/addons/io_hubs_addon/components/definitions/fog.py
+++ b/addons/io_hubs_addon/components/definitions/fog.py
@@ -13,11 +13,10 @@ class Fog(HubsComponent):
         'icon': 'MOD_OCEAN',
         'version': (1, 0, 0)
     }
-    
+
     def draw(self, context, layout, panel):
         '''Draw method to be called by the panel. The base class method will print all the component properties'''
         layout.prop(data=self, property="type")
-        print("Type:", self.type)
         if self.type == "linear":
             layout.prop(data=self, property="near")
             layout.prop(data=self, property="far")
@@ -39,7 +38,6 @@ class Fog(HubsComponent):
                                min=0,
                                max=1)
 
-    # TODO Make these properties to be displayed dynamically based on the fog type, BlenderDiplom: Done
     near: FloatProperty(
         name="Near", description="Fog Near Distance (linear only)", default=1.0)
 


### PR DESCRIPTION
We found a TODO in fog.py and resolved it: 
![grafik](https://github.com/MozillaReality/hubs-blender-exporter/assets/8123251/24761baa-6d63-428f-894a-d8057a60ce0b)
The Fog component only shows Near and Far when Linear fog is selected and only Density when Exponential fog is selected