### PR TITLE
Ported hubs exporter to 4.x - while keeping backwards compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ lib
 
 #Selenium
 __hubs_selenium_profile
+
+#VSCode
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,9 @@
   "python.analysis.extraPaths": [
     "./fake_bpy_modules_3.3-20221006"
   ],
+  "python.analysis.diagnosticSeverityOverrides": {
+    "reportInvalidTypeForm": "none",
+  },
   "editor.defaultFormatter": "ms-python.autopep8",
   "editor.formatOnSave": true,
   "editor.formatOnSaveMode": "file",

--- a/addons/io_hubs_addon/components/definitions/audio_params.py
+++ b/addons/io_hubs_addon/components/definitions/audio_params.py
@@ -114,7 +114,7 @@ class AudioParams(HubsComponent):
             self.coneOuterAngle = radians(
                 self.coneOuterAngle)
 
-            if migration_type != MigrationType.GLOBAL or is_linked(ob) or type(ob) is bpy.types.Armature:
+            if migration_type != MigrationType.GLOBAL or is_linked(ob) or type(ob) == bpy.types.Armature:
                 host_reference = get_host_reference_message(panel_type, host, ob=ob)
                 migration_report.append(
                     f"Warning: The Media Cone angles may not have migrated correctly for the Audio Params component on the {panel_type.value} {host_reference}")

--- a/addons/io_hubs_addon/components/definitions/media_frame.py
+++ b/addons/io_hubs_addon/components/definitions/media_frame.py
@@ -11,7 +11,7 @@ from mathutils import Matrix, Vector
 
 
 def is_bone(ob):
-    return type(ob) == EditBone or type(ob) == Bone
+    return type(ob) is EditBone or type(ob) is Bone
 
 
 class MediaFrameGizmo(Gizmo):
@@ -157,7 +157,7 @@ class MediaFrame(HubsComponent):
             bounds = Vector((bounds.x, bounds.z, bounds.y))
             self.bounds = bounds
 
-            if migration_type != MigrationType.GLOBAL or is_linked(ob) or type(ob) == bpy.types.Armature:
+            if migration_type is not MigrationType.GLOBAL or is_linked(ob) or type(ob) is bpy.types.Armature:
                 host_reference = get_host_reference_message(panel_type, host, ob=ob)
                 migration_report.append(
                     f"Warning: The Media Frame component's Y and Z bounds on the {panel_type.value} {host_reference} may not have migrated correctly")

--- a/addons/io_hubs_addon/components/definitions/media_frame.py
+++ b/addons/io_hubs_addon/components/definitions/media_frame.py
@@ -11,7 +11,7 @@ from mathutils import Matrix, Vector
 
 
 def is_bone(ob):
-    return type(ob) is EditBone or type(ob) is Bone
+    return type(ob) == EditBone or type(ob) == Bone
 
 
 class MediaFrameGizmo(Gizmo):
@@ -157,7 +157,7 @@ class MediaFrame(HubsComponent):
             bounds = Vector((bounds.x, bounds.z, bounds.y))
             self.bounds = bounds
 
-            if migration_type != MigrationType.GLOBAL or is_linked(ob) or type(ob) is bpy.types.Armature:
+            if migration_type != MigrationType.GLOBAL or is_linked(ob) or type(ob) == bpy.types.Armature:
                 host_reference = get_host_reference_message(panel_type, host, ob=ob)
                 migration_report.append(
                     f"Warning: The Media Frame component's Y and Z bounds on the {panel_type.value} {host_reference} may not have migrated correctly")

--- a/addons/io_hubs_addon/components/handlers.py
+++ b/addons/io_hubs_addon/components/handlers.py
@@ -233,7 +233,7 @@ def find_active_undo_step_index(undo_steps):
 
 @persistent
 def undo_stack_handler(dummy, depsgraph):
-    return  #this fails on windows, sys.stdout.fileno() is not supported
+    return  # this fails on windows, sys.stdout.fileno() is not supported
     global previous_undo_steps_dump
     global previous_undo_step_index
     global file_loading

--- a/addons/io_hubs_addon/components/handlers.py
+++ b/addons/io_hubs_addon/components/handlers.py
@@ -233,6 +233,7 @@ def find_active_undo_step_index(undo_steps):
 
 @persistent
 def undo_stack_handler(dummy, depsgraph):
+    return  #this fails on windows, sys.stdout.fileno() is not supported
     global previous_undo_steps_dump
     global previous_undo_step_index
     global file_loading

--- a/addons/io_hubs_addon/components/handlers.py
+++ b/addons/io_hubs_addon/components/handlers.py
@@ -25,7 +25,7 @@ def migrate(component, migration_type, panel_type, host, migration_report, ob=No
         was_migrated = component.migrate(
             migration_type, panel_type, instance_version, host, migration_report, ob=ob)
 
-        if type(was_migrated) is not bool:
+        if type(was_migrated) != bool:
             print(f"Warning: the {component.get_display_name()} component didn't return whether a migration occurred.")
             # Fall back to assuming there was a migration since the version increased.
             was_migrated = True

--- a/addons/io_hubs_addon/components/utils.py
+++ b/addons/io_hubs_addon/components/utils.py
@@ -297,7 +297,7 @@ def display_wrapped_text(layout, wrapped_text, *, heading_icon='NONE'):
 def get_host_reference_message(panel_type, host, ob=None):
     '''The ob argument is used for bone hosts and is the armature object, but will fall back to the armature if the armature object isn't available.'''
     if panel_type == PanelType.BONE:
-        ob_type = "armature" if type(ob) is bpy.types.Armature else "object"
+        ob_type = "armature" if type(ob) == bpy.types.Armature else "object"
         host_reference = f"\"{host.name}\" in {ob_type} \"{ob.name_full}\""
     else:
         host_reference = f"\"{host.name_full}\""

--- a/addons/io_hubs_addon/components/utils.py
+++ b/addons/io_hubs_addon/components/utils.py
@@ -210,7 +210,7 @@ else:  # Linux/Mac
 
 @contextmanager
 def redirect_c_stdout(binary_stream):
-    #this causes an error on windows when the addon is enabled using:  bpy.ops.preferences.addon_enable(module="io_hubs_addon")
+    # this causes an error on windows when the addon is enabled using:  bpy.ops.preferences.addon_enable(module="io_hubs_addon")
     stdout_file_descriptor = sys.stdout.fileno()
     original_stdout_file_descriptor_copy = os.dup(stdout_file_descriptor)
     try:

--- a/addons/io_hubs_addon/components/utils.py
+++ b/addons/io_hubs_addon/components/utils.py
@@ -210,6 +210,7 @@ else:  # Linux/Mac
 
 @contextmanager
 def redirect_c_stdout(binary_stream):
+    #this causes an error on windows when the addon is enabled using:  bpy.ops.preferences.addon_enable(module="io_hubs_addon")
     stdout_file_descriptor = sys.stdout.fileno()
     original_stdout_file_descriptor_copy = os.dup(stdout_file_descriptor)
     try:

--- a/addons/io_hubs_addon/io/gltf_exporter.py
+++ b/addons/io_hubs_addon/io/gltf_exporter.py
@@ -149,23 +149,28 @@ class glTF2ExportUserExtension:
         self.add_hubs_components(gltf2_object, blender_object, export_settings)
 
     def gather_material_hook(self, gltf2_object, blender_material, export_settings):
+        print("Gathering material:", blender_material.name)
+        if blender_material.name == "WithLightmap":
+            print("export_settings:", export_settings)
         if not self.properties.enabled:
+            print("Not enabled")
             return
 
         self.add_hubs_components(
             gltf2_object, blender_material, export_settings)
-
+        print("added components")
         from .utils import gather_lightmap_texture_info
         if blender_material.node_tree and blender_material.use_nodes:
             lightmap_texture_info = gather_lightmap_texture_info(
                 blender_material, export_settings)
+            print("gathered lightmap texture info:", lightmap_texture_info)
             if lightmap_texture_info:
                 gltf2_object.extensions["MOZ_lightmap"] = self.Extension(
                     name="MOZ_lightmap",
                     extension=lightmap_texture_info,
                     required=False,
                 )
-
+        print("Hook done")
     def gather_material_unlit_hook(self, gltf2_object, blender_material, export_settings):
         self.gather_material_hook(
             gltf2_object, blender_material, export_settings)

--- a/addons/io_hubs_addon/io/gltf_exporter.py
+++ b/addons/io_hubs_addon/io/gltf_exporter.py
@@ -149,28 +149,22 @@ class glTF2ExportUserExtension:
         self.add_hubs_components(gltf2_object, blender_object, export_settings)
 
     def gather_material_hook(self, gltf2_object, blender_material, export_settings):
-        print("Gathering material:", blender_material.name)
-        if blender_material.name == "WithLightmap":
-            print("export_settings:", export_settings)
         if not self.properties.enabled:
-            print("Not enabled")
             return
 
         self.add_hubs_components(
             gltf2_object, blender_material, export_settings)
-        print("added components")
         from .utils import gather_lightmap_texture_info
         if blender_material.node_tree and blender_material.use_nodes:
             lightmap_texture_info = gather_lightmap_texture_info(
                 blender_material, export_settings)
-            print("gathered lightmap texture info:", lightmap_texture_info)
             if lightmap_texture_info:
                 gltf2_object.extensions["MOZ_lightmap"] = self.Extension(
                     name="MOZ_lightmap",
                     extension=lightmap_texture_info,
                     required=False,
                 )
-        print("Hook done")
+
     def gather_material_unlit_hook(self, gltf2_object, blender_material, export_settings):
         self.gather_material_hook(
             gltf2_object, blender_material, export_settings)

--- a/addons/io_hubs_addon/io/utils.py
+++ b/addons/io_hubs_addon/io/utils.py
@@ -341,12 +341,11 @@ def gather_lightmap_texture_info(blender_material, export_settings):
     # TODO this assumes a single image directly connected to the socket
     blender_image = texture_socket.links[0].from_node.image
     texture = gather_texture(blender_image, export_settings)
-    if bpy.app.version < (3, 2, 0):
+    if bpy.app.version < (3, 2, 0) or bpy.app.version >= (4, 0, 0):
         tex_transform, tex_coord = gltf2_blender_gather_texture_info.__gather_texture_transform_and_tex_coord(
             texture_socket, export_settings)
     else:
-        #tex_transform, tex_coord, _ = gltf2_blender_gather_texture_info.__gather_texture_transform_and_tex_coord(
-        tex_transform, tex_coord = gltf2_blender_gather_texture_info.__gather_texture_transform_and_tex_coord( # gltf2 Blender 4.x only returns 2 parmas
+        tex_transform, tex_coord, _ = gltf2_blender_gather_texture_info.__gather_texture_transform_and_tex_coord(
             texture_socket, export_settings)
     texture_info = gltf2_io.TextureInfo(
         extensions=gltf2_blender_gather_texture_info.__gather_extensions(
@@ -357,7 +356,6 @@ def gather_lightmap_texture_info(blender_material, export_settings):
     )
 
     if not texture_info:
-        print("Found no texture info")
         return
 
     return {

--- a/addons/io_hubs_addon/io/utils.py
+++ b/addons/io_hubs_addon/io/utils.py
@@ -75,9 +75,8 @@ def gather_image(blender_image, export_settings):
             mime_type = "image/png"
     else:
         mime_type = "image/jpeg"
-    d1 = HubsExportImage.from_blender_image(blender_image)
-    data = d1.encode(mime_type, export_settings)
-    if type(data) is tuple:
+    data = HubsExportImage.from_blender_image(blender_image).encode(mime_type, export_settings)
+    if type(data) == tuple:
         data = data[0]
 
     if export_settings['gltf_format'] == 'GLTF_SEPARATE':
@@ -157,13 +156,13 @@ def gather_property(export_settings, blender_object, target, property_name):
             return gather_vec_property(export_settings, blender_object, target, property_name)
 
     elif (property_definition.bl_rna.identifier == 'PointerProperty'):
-        if type(property_value) is bpy.types.Object:
+        if type(property_value) == bpy.types.Object:
             return gather_node_property(export_settings, blender_object, target, property_name)
-        elif type(property_value) is bpy.types.Material:
+        elif type(property_value) == bpy.types.Material:
             return gather_material_property(export_settings, blender_object, target, property_name)
-        elif type(property_value) is bpy.types.Image:
+        elif type(property_value) == bpy.types.Image:
             return gather_image_property(export_settings, blender_object, target, property_name)
-        elif type(property_value) is bpy.types.Texture:
+        elif type(property_value) == bpy.types.Texture:
             return gather_texture_property(export_settings, blender_object, target, property_name)
 
     return gltf2_blender_extras.__to_json_compatible(property_value)

--- a/addons/io_hubs_addon/io/utils.py
+++ b/addons/io_hubs_addon/io/utils.py
@@ -75,9 +75,8 @@ def gather_image(blender_image, export_settings):
             mime_type = "image/png"
     else:
         mime_type = "image/jpeg"
-
-    data = HubsExportImage.from_blender_image(blender_image).encode(mime_type, export_settings)
-
+    d1 = HubsExportImage.from_blender_image(blender_image)
+    data = d1.encode(mime_type, export_settings)
     if type(data) == tuple:
         data = data[0]
 
@@ -105,7 +104,6 @@ def gather_image(blender_image, export_settings):
 @cached
 def gather_texture(blender_image, export_settings):
     image = gather_image(blender_image, export_settings)
-
     if not image:
         return None
 
@@ -335,9 +333,8 @@ def gather_lightmap_texture_info(blender_material, export_settings):
     lightmap_node = next(
         (n for n in nodes if isinstance(n, MozLightmapNode)), None)
 
-    if not lightmap_node:
+    if lightmap_node is None:
         return
-
     texture_socket = lightmap_node.inputs.get("Lightmap")
     intensity = lightmap_node.intensity
 
@@ -348,7 +345,8 @@ def gather_lightmap_texture_info(blender_material, export_settings):
         tex_transform, tex_coord = gltf2_blender_gather_texture_info.__gather_texture_transform_and_tex_coord(
             texture_socket, export_settings)
     else:
-        tex_transform, tex_coord, _ = gltf2_blender_gather_texture_info.__gather_texture_transform_and_tex_coord(
+        #tex_transform, tex_coord, _ = gltf2_blender_gather_texture_info.__gather_texture_transform_and_tex_coord(
+        tex_transform, tex_coord = gltf2_blender_gather_texture_info.__gather_texture_transform_and_tex_coord( # gltf2 Blender 4.x only returns 2 parmas
             texture_socket, export_settings)
     texture_info = gltf2_io.TextureInfo(
         extensions=gltf2_blender_gather_texture_info.__gather_extensions(
@@ -359,6 +357,7 @@ def gather_lightmap_texture_info(blender_material, export_settings):
     )
 
     if not texture_info:
+        print("Found no texture info")
         return
 
     return {

--- a/addons/io_hubs_addon/io/utils.py
+++ b/addons/io_hubs_addon/io/utils.py
@@ -76,7 +76,7 @@ def gather_image(blender_image, export_settings):
     else:
         mime_type = "image/jpeg"
     data = HubsExportImage.from_blender_image(blender_image).encode(mime_type, export_settings)
-    if type(data) == tuple:
+    if type(data) is tuple:
         data = data[0]
 
     if export_settings['gltf_format'] == 'GLTF_SEPARATE':
@@ -156,13 +156,13 @@ def gather_property(export_settings, blender_object, target, property_name):
             return gather_vec_property(export_settings, blender_object, target, property_name)
 
     elif (property_definition.bl_rna.identifier == 'PointerProperty'):
-        if type(property_value) == bpy.types.Object:
+        if type(property_value) is bpy.types.Object:
             return gather_node_property(export_settings, blender_object, target, property_name)
-        elif type(property_value) == bpy.types.Material:
+        elif type(property_value) is bpy.types.Material:
             return gather_material_property(export_settings, blender_object, target, property_name)
-        elif type(property_value) == bpy.types.Image:
+        elif type(property_value) is bpy.types.Image:
             return gather_image_property(export_settings, blender_object, target, property_name)
-        elif type(property_value) == bpy.types.Texture:
+        elif type(property_value) is bpy.types.Texture:
             return gather_texture_property(export_settings, blender_object, target, property_name)
 
     return gltf2_blender_extras.__to_json_compatible(property_value)

--- a/addons/io_hubs_addon/io/utils.py
+++ b/addons/io_hubs_addon/io/utils.py
@@ -332,7 +332,7 @@ def gather_lightmap_texture_info(blender_material, export_settings):
     lightmap_node = next(
         (n for n in nodes if isinstance(n, MozLightmapNode)), None)
 
-    if lightmap_node is None:
+    if not lightmap_node:
         return
     texture_socket = lightmap_node.inputs.get("Lightmap")
     intensity = lightmap_node.intensity

--- a/addons/io_hubs_addon/nodes/lightmap.py
+++ b/addons/io_hubs_addon/nodes/lightmap.py
@@ -23,7 +23,6 @@ class NODE_MT_mozilla_hubs_nodes(bpy.types.Menu):
 
     def draw(self, context):
         layout = self.layout
-        # Example of adding a custom node to the menu
         layout.operator("node.add_node", text="MOZ_lightmap settings").type = "moz_lightmap.node"
 
 class MozLightmapNode(Node):
@@ -33,7 +32,6 @@ class MozLightmapNode(Node):
     bl_icon = 'LIGHT'
     bl_width_min = 216.3
     bl_width_max = 330.0
-
     intensity: bpy.props.FloatProperty(
         name="Intensity", soft_min=0, soft_max=1, default=1)
 
@@ -72,13 +70,12 @@ def unregister_blender_4():
 
 def register_blender_3():
     print("Using Blender 3x")
-
     bpy.utils.register_class(MozLightmapNode)
-    nodeitems_utils.register_manual_map(create_node_categories)
+    nodeitems_utils.register_node_categories("MOZ_NODES", node_categories)
 
 def unregister_blender_3():
     bpy.utils.unregister_class(MozLightmapNode)
-    nodeitems_utils.unregister_manual_map(create_node_categories)
+    nodeitems_utils.unregister_node_categories("MOZ_NODES", node_categories)
 
 def register():
     if bpy.app.version < (4, 0, 0):

--- a/addons/io_hubs_addon/nodes/lightmap.py
+++ b/addons/io_hubs_addon/nodes/lightmap.py
@@ -24,7 +24,7 @@ class NODE_MT_mozilla_hubs_nodes(bpy.types.Menu):
     def draw(self, context):
         layout = self.layout
         # Example of adding a custom node to the menu
-        layout.operator("node.add_node", text="MOZ_lightmap settings").type = "MozLightmapNode"
+        layout.operator("node.add_node", text="MOZ_lightmap settings").type = "moz_lightmap.node"
 
 class MozLightmapNode(Node):
     """MOZ_lightmap settings node"""
@@ -53,29 +53,41 @@ class MozLightmapNode(Node):
     def draw_label(self):
         return "MOZ_lightmap"
 
-# def create_node_categories():
-#     return [NodeCategory("MOZ_NODES", "Moz Nodes", items=node_categories)]
+def create_node_categories():
+    return [NodeCategory("MOZ_NODES", "Moz Nodes", items=node_categories)]
 
 def menu_func(self, context):
     self.layout.menu("NODE_MT_mozilla_hubs_nodes")
 
-def register():
+def register_blender_4():
+    print("Using Blender 4x")
     bpy.utils.register_class(NODE_MT_mozilla_hubs_nodes)
     bpy.types.NODE_MT_shader_node_add_all.append(menu_func)
     bpy.utils.register_class(MozLightmapNode)
 
-def unregister():
+def unregister_blender_4():
     bpy.types.NODE_MT_shader_node_add_all.remove(menu_func)
     bpy.utils.unregister_class(NODE_MT_mozilla_hubs_nodes)
     bpy.utils.unregister_class(MozLightmapNode)
 
+def register_blender_3():
+    print("Using Blender 3x")
 
+    bpy.utils.register_class(MozLightmapNode)
+    nodeitems_utils.register_manual_map(create_node_categories)
 
-# def register():
-#     bpy.utils.register_class(MozLightmapNode)
-#     nodeitems_utils.register_manual_map(create_node_categories)
+def unregister_blender_3():
+    bpy.utils.unregister_class(MozLightmapNode)
+    nodeitems_utils.unregister_manual_map(create_node_categories)
 
-# def unregister():
-#     bpy.utils.unregister_class(MozLightmapNode)
-#     nodeitems_utils.unregister_manual_map(create_node_categories)
+def register():
+    if bpy.app.version < (4, 0, 0):
+        register_blender_3()
+    else:
+        register_blender_4()
 
+def unregister():
+    if bpy.app.version < (4, 0, 0):
+        unregister_blender_3()
+    else:
+        unregister_blender_4()

--- a/addons/io_hubs_addon/nodes/lightmap.py
+++ b/addons/io_hubs_addon/nodes/lightmap.py
@@ -82,7 +82,7 @@ def register_blender_3():
 
 def unregister_blender_3():
     bpy.utils.unregister_class(MozLightmapNode)
-    nodeitems_utils.unregister_node_categories("MOZ_NODES", node_categories)
+    nodeitems_utils.unregister_node_categories("MOZ_NODES")
 
 
 def register():

--- a/addons/io_hubs_addon/nodes/lightmap.py
+++ b/addons/io_hubs_addon/nodes/lightmap.py
@@ -17,6 +17,14 @@ node_categories = [
     ]),
 ]
 
+class NODE_MT_mozilla_hubs_nodes(bpy.types.Menu):
+    bl_label = "Hubs"
+    bl_idname = "NODE_MT_mozilla_hubs_nodes"
+
+    def draw(self, context):
+        layout = self.layout
+        # Example of adding a custom node to the menu
+        layout.operator("node.add_node", text="MOZ_lightmap settings").type = "MozLightmapNode"
 
 class MozLightmapNode(Node):
     """MOZ_lightmap settings node"""
@@ -45,12 +53,29 @@ class MozLightmapNode(Node):
     def draw_label(self):
         return "MOZ_lightmap"
 
+# def create_node_categories():
+#     return [NodeCategory("MOZ_NODES", "Moz Nodes", items=node_categories)]
+
+def menu_func(self, context):
+    self.layout.menu("NODE_MT_mozilla_hubs_nodes")
 
 def register():
+    bpy.utils.register_class(NODE_MT_mozilla_hubs_nodes)
+    bpy.types.NODE_MT_shader_node_add_all.append(menu_func)
     bpy.utils.register_class(MozLightmapNode)
-    nodeitems_utils.register_node_categories("MOZ_NODES", node_categories)
-
 
 def unregister():
+    bpy.types.NODE_MT_shader_node_add_all.remove(menu_func)
+    bpy.utils.unregister_class(NODE_MT_mozilla_hubs_nodes)
     bpy.utils.unregister_class(MozLightmapNode)
-    nodeitems_utils.unregister_node_categories("MOZ_NODES")
+
+
+
+# def register():
+#     bpy.utils.register_class(MozLightmapNode)
+#     nodeitems_utils.register_manual_map(create_node_categories)
+
+# def unregister():
+#     bpy.utils.unregister_class(MozLightmapNode)
+#     nodeitems_utils.unregister_manual_map(create_node_categories)
+

--- a/addons/io_hubs_addon/nodes/lightmap.py
+++ b/addons/io_hubs_addon/nodes/lightmap.py
@@ -17,13 +17,16 @@ node_categories = [
     ]),
 ]
 
+
 class NODE_MT_mozilla_hubs_nodes(bpy.types.Menu):
+    """Add node menu for Blender 4.x"""
     bl_label = "Hubs"
     bl_idname = "NODE_MT_mozilla_hubs_nodes"
 
     def draw(self, context):
         layout = self.layout
         layout.operator("node.add_node", text="MOZ_lightmap settings").type = "moz_lightmap.node"
+
 
 class MozLightmapNode(Node):
     """MOZ_lightmap settings node"""
@@ -51,37 +54,43 @@ class MozLightmapNode(Node):
     def draw_label(self):
         return "MOZ_lightmap"
 
+
 def create_node_categories():
     return [NodeCategory("MOZ_NODES", "Moz Nodes", items=node_categories)]
+
 
 def menu_func(self, context):
     self.layout.menu("NODE_MT_mozilla_hubs_nodes")
 
+
 def register_blender_4():
-    print("Using Blender 4x")
     bpy.utils.register_class(NODE_MT_mozilla_hubs_nodes)
     bpy.types.NODE_MT_shader_node_add_all.append(menu_func)
     bpy.utils.register_class(MozLightmapNode)
+
 
 def unregister_blender_4():
     bpy.types.NODE_MT_shader_node_add_all.remove(menu_func)
     bpy.utils.unregister_class(NODE_MT_mozilla_hubs_nodes)
     bpy.utils.unregister_class(MozLightmapNode)
 
+
 def register_blender_3():
-    print("Using Blender 3x")
     bpy.utils.register_class(MozLightmapNode)
     nodeitems_utils.register_node_categories("MOZ_NODES", node_categories)
+
 
 def unregister_blender_3():
     bpy.utils.unregister_class(MozLightmapNode)
     nodeitems_utils.unregister_node_categories("MOZ_NODES", node_categories)
+
 
 def register():
     if bpy.app.version < (4, 0, 0):
         register_blender_3()
     else:
         register_blender_4()
+
 
 def unregister():
     if bpy.app.version < (4, 0, 0):

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "hubs-blender-exporter_fixes",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}

--- a/tests/export_gltf.py
+++ b/tests/export_gltf.py
@@ -16,34 +16,35 @@ import bpy
 import os
 import sys
 
-bpy.ops.preferences.addon_enable(module="io_hubs_addon")
 
-try:
-    argv = sys.argv
-    if "--" in argv:
-        argv = argv[argv.index("--") + 1:]  # get all args after "--"
-    else:
-        argv = []
+bpy.ops.preferences.addon_enable(module="io_hubs_addon") #it throws an error on windows and it's not necessary, since the commandline already enables the addon
 
-    extension = '.gltf'
-    if '--glb' in argv:
-        extension = '.glb'
+#try:
+argv = sys.argv
+if "--" in argv:
+    argv = argv[argv.index("--") + 1:]  # get all args after "--"
+else:
+    argv = []
 
-    path = os.path.splitext(bpy.data.filepath)[0] + extension
-    path_parts = os.path.split(path)
-    output_dir = os.path.join(path_parts[0], argv[0])
-    if not os.path.exists(output_dir):
-        os.makedirs(output_dir)
-    args = {
-        # Settings from "Remember Export Settings"
-        **dict(bpy.context.scene.get('glTF2ExportSettings', {})),
+extension = '.glb' if '--glb' in argv else '.gltf'
 
-        'export_format': ('GLB' if extension == '.glb' else 'GLTF_SEPARATE'),
-        'filepath': os.path.join(output_dir, path_parts[1]),
-        'export_cameras': True,
-        'export_extras': True
-    }
-    bpy.ops.export_scene.gltf(**args)
-except Exception as err:
-    print(err, file=sys.stderr)
-    sys.exit(1)
+path = os.path.splitext(bpy.data.filepath)[0] + extension
+path_parts = os.path.split(path)
+output_dir = os.path.join(path_parts[0], argv[0])
+print("Saving to " + output_dir)
+# if not os.path.exists(output_dir): #no need, Blender export always creates the dirs
+#     os.makedirs(output_dir)
+args = {
+    # Settings from "Remember Export Settings"
+    **dict(bpy.context.scene.get('glTF2ExportSettings', {})),
+
+    'export_format': ('GLB' if extension == '.glb' else 'GLTF_SEPARATE'),
+    'filepath': output_dir,#, path_parts[1]),
+    'export_cameras': True,
+    'export_extras': True
+}
+print("Got args, exporting")
+bpy.ops.export_scene.gltf(**args)
+# except Exception as err:
+#     print(err, file=sys.stderr)
+#     sys.exit(1)

--- a/tests/package.json
+++ b/tests/package.json
@@ -2,7 +2,10 @@
   "name": "io-hubs-addon-tests",
   "version": "1.0.0",
   "description": "Test suite for io-hubs-addon",
-  "dependencies": {},
+  "dependencies": {
+    "g": "^2.0.1",
+    "yarn": "^1.22.22"
+  },
   "devDependencies": {
     "eslint": "^6.8.0",
     "gltf-validator": "^2.0.0-dev.3.2",

--- a/tests/roundtrip_gltf.py
+++ b/tests/roundtrip_gltf.py
@@ -16,37 +16,37 @@ import bpy
 import os
 import sys
 
-try:
-    argv = sys.argv
-    if "--" in argv:
-        argv = argv[argv.index("--") + 1:]  # get all args after "--"
-    else:
-        argv = []
+#try:
+argv = sys.argv
+if "--" in argv:
+    argv = argv[argv.index("--") + 1:]  # get all args after "--"
+else:
+    argv = []
 
-    filepath = argv[0]
+filepath = argv[0]
+print("Filepath: " + filepath)
+bpy.ops.object.select_all(action='SELECT')
+bpy.ops.object.delete(use_global=False)
 
-    bpy.ops.object.select_all(action='SELECT')
-    bpy.ops.object.delete(use_global=False)
+bpy.ops.import_scene.gltf(filepath=argv[0])
+print("Importing: " + argv[0])
+extension = '.gltf'
+export_format = 'GLTF_SEPARATE'
+if '--glb' in argv:
+    extension = '.glb'
+    export_format = 'GLB'
 
-    bpy.ops.import_scene.gltf(filepath=argv[0])
-
-    extension = '.gltf'
-    export_format = 'GLTF_SEPARATE'
-    if '--glb' in argv:
-        extension = '.glb'
-        export_format = 'GLB'
-
-    path = os.path.splitext(filepath)[0] + extension
-    path_parts = os.path.split(path)
-    output_dir = os.path.join(path_parts[0], argv[1])
-    if not os.path.exists(output_dir):
-        os.makedirs(output_dir)
-    if '--no-sample-anim' in argv:
-        bpy.ops.export_scene.gltf(export_format=export_format, filepath=os.path.join(
-            output_dir, path_parts[1]), export_force_sampling=False)
-    else:
-        bpy.ops.export_scene.gltf(
-            export_format=export_format, filepath=os.path.join(output_dir, path_parts[1]))
-except Exception as err:
-    print(err, file=sys.stderr)
-    sys.exit(1)
+path = os.path.splitext(filepath)[0] + extension
+path_parts = os.path.split(path)
+output_dir = os.path.join(path_parts[0], argv[1])
+if not os.path.exists(output_dir):
+    os.makedirs(output_dir)
+if '--no-sample-anim' in argv:
+    bpy.ops.export_scene.gltf(export_format=export_format, filepath=os.path.join(
+        output_dir, path_parts[1]), export_force_sampling=False)
+else:
+    bpy.ops.export_scene.gltf(
+        export_format=export_format, filepath=os.path.join(output_dir, path_parts[1]))
+# except Exception as err:
+#     print(err, file=sys.stderr)
+#     sys.exit(1)

--- a/tests/test/test_export.js
+++ b/tests/test/test_export.js
@@ -16,6 +16,11 @@ const blenderVersions = (() => {
       "blender"
     ];
   }
+  else if (process.platform == 'win32') {
+    return [
+      "C:\\Program Files\\Blender Foundation\\Blender 3.6\\blender.exe",
+    ];
+  }
 })();
 
 var utils = require('./utils.js').utils;
@@ -32,15 +37,16 @@ describe('Exporter', function () {
 
     variants.forEach(function (variant) {
       const args = variant[1];
-      describe(blenderVersion + '_export' + variant[0], function () {
+      describe(blenderVersion + ', exporting:' + variant[0], function () {
         blenderSampleScenes.forEach((scene) => {
           it(scene, function (done) {
             let outDirName = 'out' + blenderVersion + variant[0];
             let blenderPath = `scenes/${scene}.blend`;
             let ext = args.indexOf('--glb') === -1 ? '.gltf' : '.glb';
-            let outDirPath = path.resolve(OUT_PREFIX, 'scenes', outDirName);
+            let outDirPath = path.resolve(OUT_PREFIX, 'scenes');
             let dstPath = path.resolve(outDirPath, `${scene}${ext}`);
-            utils.blenderFileToGltf(blenderVersion, blenderPath, outDirPath, (error) => {
+            //utils.blenderFileToGltf(blenderVersion, blenderPath, outDirPath, (error) => {
+            utils.blenderFileToGltf(blenderVersion, blenderPath, dstPath, (error) => {
               if (error)
                 return done(error);
 
@@ -51,9 +57,9 @@ describe('Exporter', function () {
       });
     });
 
-    describe(blenderVersion + '_export_results', function () {
-      let outDirName = 'out' + blenderVersion;
-      let outDirPath = path.resolve(OUT_PREFIX, 'scenes', outDirName);
+    describe(blenderVersion + ' export_results', function () {
+      let outDirName = 'out';// + blenderVersion;
+      let outDirPath = path.resolve(OUT_PREFIX, 'scenes');//, outDirName);
 
       it('can export link', function () {
         let gltfPath = path.resolve(outDirPath, 'link.gltf');

--- a/tests/test/utils.js
+++ b/tests/test/utils.js
@@ -6,12 +6,14 @@ const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12
 
 function blenderFileToGltf(blenderVersion, blenderPath, outDirName, done, options = '') {
   const { exec } = require('child_process');
-  const cmd = `${blenderVersion} -b --factory-startup --addons io_hubs_addon -noaudio ${blenderPath} --python export_gltf.py -- ${outDirName} ${options}`;
+  //const cmd = `"${blenderVersion}" "${blenderPath}" -b --factory-startup --addons io_hubs_addon -noaudio --python export_gltf.py -- ${outDirName} ${options}`;
+  //const cmd = `"${blenderVersion}" "${blenderPath}" -b --factory-startup --addons io_hubs_addon -noaudio --python export_gltf.py -- ${outDirName}`;
+  const cmd = `"${blenderVersion}" "${blenderPath}" -b --factory-startup -noaudio --python export_gltf.py -- ${outDirName.replace(/\\/g, '//')} `;
   var prc = exec(cmd, (error, stdout, stderr) => {
     //if (stderr) process.stderr.write(stderr);
-
+    console.log("Exporter resulsts\n" + stdout);
     if (error) {
-      console.log(stdout);
+     
       done(error);
       return;
     }
@@ -24,7 +26,7 @@ function blenderRoundtripGltf(blenderVersion, gltfPath, outDirName, done, option
   const cmd = `${blenderVersion} -b --factory-startup --addons io_hubs_addon -noaudio --python roundtrip_gltf.py -- ${gltfPath} ${outDirName} ${options}`;
   var prc = exec(cmd, (error, stdout, stderr) => {
     //if (stderr) process.stderr.write(stderr);
-
+    console.log("Roundtrip resulsts\n" + stdout);
     if (error) {
       done(error);
       return;

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -572,6 +572,11 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
+g@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/g/-/g-2.0.1.tgz#0b5963ebd0ca70e3bc8c6766934a021821c8b857"
+  integrity sha512-Fi6Ng5fZ/ANLQ15H11hCe+09sgUoNvDEBevVgx3KoYOhsH5iLNPn54hx0jPZ+3oSWr+xajnp2Qau9VmPsc7hTA==
+
 get-caller-file@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
@@ -1687,3 +1692,8 @@ yargs@13.3.2, yargs@^13.2.2, yargs@^13.3.0:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
+
+yarn@^1.22.22:
+  version "1.22.22"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.22.tgz#ac34549e6aa8e7ead463a7407e1c7390f61a6610"
+  integrity sha512-prL3kGtyG7o9Z9Sv8IPfBNrWTDmXB4Qbes8A9rEzt6wkJV8mUvoirjU0Mp3GGAU06Y0XQyA3/2/RQFVuK7MTfg==


### PR DESCRIPTION
Changes: 
MOZ_lightmaps had to be overhauled, add node menu has changed in 4.0
material gathering behavior for materials including lightmaps apparently got changed in the gltf exporter > 3.2 and reverted in 4.0, so we only added the version check for > 4.
The rest is untested, but we expect it to behave normally.

The automated tests for versions < 3.5 seem to fail, however installing the changes manually in 3.4 and exporting the ambient light scene does result in a valid glb, contrary to the yarn test result