### PR TITLE
Switch the audio-params override to be disabled by default.

### DIFF
--- a/addons/io_hubs_addon/components/definitions/audio_params.py
+++ b/addons/io_hubs_addon/components/definitions/audio_params.py
@@ -18,13 +18,13 @@ class AudioParams(HubsComponent):
         'display_name': 'Audio Params',
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
-        'version': (1, 0, 0)
+        'version': (1, 0, 1)
     }
 
     overrideAudioSettings: BoolProperty(
         name="Override Audio Settings",
         description="Override Audio Settings",
-        default=True)
+        default=False)
 
     audioType: EnumProperty(
         name="Audio Type",
@@ -118,6 +118,11 @@ class AudioParams(HubsComponent):
                 host_reference = get_host_reference_message(panel_type, host, ob=ob)
                 migration_report.append(
                     f"Warning: The Media Cone angles may not have migrated correctly for the Audio Params component on the {panel_type.value} {host_reference}")
+
+        if instance_version <= (1, 0, 0):
+            if self.get("overrideAudioSettings") is None:
+                migration_occurred = True
+                self.overrideAudioSettings = True
 
         return migration_occurred
 

--- a/addons/io_hubs_addon/components/definitions/audio_target.py
+++ b/addons/io_hubs_addon/components/definitions/audio_target.py
@@ -122,6 +122,10 @@ class AudioTarget(HubsComponent):
         description="Show debug visuals",
         default=False)
 
+    @classmethod
+    def init(cls, obj):
+        obj.hubs_component_audio_params.overrideAudioSettings = True
+
     def draw(self, context, layout, panel):
         dep_name = AudioSource.get_name()
 

--- a/addons/io_hubs_addon/components/definitions/audio_zone.py
+++ b/addons/io_hubs_addon/components/definitions/audio_zone.py
@@ -61,6 +61,10 @@ class AudioZone(HubsComponent):
 
         return gizmo
 
+    @classmethod
+    def init(cls, obj):
+        obj.hubs_component_audio_params.overrideAudioSettings = True
+
     def migrate(self, migration_type, panel_type, instance_version, host, migration_report, ob=None):
         migration_occurred = False
         if instance_version < (1, 0, 0):


### PR DESCRIPTION
Make audio zones and audio targets specifically enable the override because that's their whole purpose. When migrating, check to see if the field is present, if it is then its value is respected otherwise the override is set to true in order to preserve the previous state.

This addresses issue #199  It is also needed for properly importing the audio-params component in #63 