### PR TITLE
Make avatar to viewport default to false

### DIFF
--- a/addons/io_hubs_addon/debugger.py
+++ b/addons/io_hubs_addon/debugger.py
@@ -976,7 +976,7 @@ class HubsSceneDebuggerRoomExportPrefs(bpy.types.PropertyGroup):
     avatar_to_viewport: bpy.props.BoolProperty(
         name='Spawn using viewport transform',
         description='Spawn the avatar in the current viewport camera position/rotation',
-        default=True, options=set())
+        default=False, options=set())
 
 
 class HubsSceneProject(bpy.types.PropertyGroup):


### PR DESCRIPTION
I've found myself not wanting the the avatar to be spawned on the Blender viewport camera position so I think it makes more sense to make False the default.