### PR TITLE
CI: runs tests on 4.x versions of Blender, drops tests on unsupported versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,8 +57,9 @@ jobs:
     needs: lint
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        version: ["3.5.0", "3.4.0", "3.3.1", "2.93.9"]
+        version: ["3.6.23", "4.0.2", "4.1.1", "4.2.19", "4.3.2", "4.4.3", "4.5.8", "5.0.1", "5.1.1" ]
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## What?
CI: runs tests on versions 3.6–5.1 of Blender, drops tests on unsupported versions


## Why?
We need to test against all supported versions, but not against unsupported versions


## How to test
1. Navigate to Actions tab of this repo
2. Observe that all tests pass

## Documentation of functionality
The docs don't state what versions of Blender this works with, so no changes are necessary


## Limitations

