### PR TITLE
Fix migration when enabling the add-on in Blender 5.1

### DIFF
--- a/addons/io_hubs_addon/__init__.py
+++ b/addons/io_hubs_addon/__init__.py
@@ -65,7 +65,7 @@ def register():
         def registration_migration():
             # Passing True as the first argument of the operator forces an undo step to be created.
             bpy.ops.wm.migrate_hubs_components(
-                True, is_registration=True)
+                'EXEC_DEFAULT', True, is_registration=True)
         bpy.app.timers.register(registration_migration)
 
 


### PR DESCRIPTION
## What?
<!-- REQUIRED — Explain what your pull request does -->
Explicitly specifies the execution context when calling `migrate_hubs_components` during the registration of the add-on in the middle of a session instead of relying on the execution context being passed automatically.

## Why?
<!-- REQUIRED — Explain why you're opening this pull request, what limitations does it address, etc..  If you're fixing a bug with an open bug report you can just link to the bug report -->
Blender 5.1 now requires the execution context to be specified as well if you want to push an undo step when calling an operator.  Blender 5.1 no longer auto-detects which option you specified if you only specify one and assumes that you are specifying the execution context.  If you try to only specify whether to push an undo step without specifying the execution context, it fails with the following error:

```Python
Traceback (most recent call last):
    File "/path/to/io_hubs_addon/__init__.py", line 67, in registration_migration
    bpy.ops.wm.migrate_hubs_components(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        True, is_registration=True)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: _bpy.ops.call() argument 3 must be str, not bool
```

## Examples
<!-- OPTIONAL — If applicable, give examples of the changes the user will observe, e.g. screenshots, videos, diagrams, console output, etc., otherwise put "N/A" or remove the section.  Including examples of before the PR and after the PR is encouraged. -->
N/A

## How to test
<!-- REQUIRED — Give the steps required to test your pull request -->

1. Open Blender 5.1 from a terminal
2. Disable the add-on (if enabled)
3. Enable the add-on.
4. See that no error about `bpy.ops.wm.migrate_hubs_components` is printed to the terminal.
5. If you have a blend file with components from an add-on before version 1.0, load that with the add-on disabled, enable the add-on, and see that the migration happens as expected.
6. If you repeat the above without this fix, you should see an error about `bpy.ops.wm.migrate_hubs_components` printed to the terminal when enabling the add-on.

## Documentation of functionality
<!-- REQUIRED — Link to the accompanying documentation pull request or identify where the documentation is located in this pull request.  If no documentation is needed, please specify this here -->
No functionality is changed, this just ensures the current behaviour is maintained for Blender 5.1.

## Limitations
<!-- OPTIONAL — If there is anything you decided not to do/support in this PR that might otherwise be expected, list them here along with the reason why you didn't do/support them, otherwise put "None" -->
None.

## Alternative implementations considered
<!-- OPTIONAL — If there are any alternative ways of implementing this change that you thought of, but decided against, list them here along with why they were discarded, otherwise put "None" -->
None.

## Open questions
<!-- OPTIONAL — If you have any questions, put them here, otherwise put "None" -->
None.

## Additional details or related context
<!-- OPTIONAL — If there are any other details that you think the reviewers should be aware of that you didn't put elsewhere, e.g. links to related issues, pull requests, references you used, notes on weird things, attribution, etc., put them here, otherwise put "None" -->
The change in behaviour is potentially because of the Python upgrade from 3.11 to 3.13, but this specific change (with regard to calling operators) is unreported in the 5.1 release notes.

The specified execution context is the default execution context for operators (so it should be the same as what was automatically passed previously).

Previous versions of Blender shouldn't be affected because both positional options have always been present in this order.

Blender 3.6 and previous also had an option to override the context as the first positional argument (which isn't specified here), but not specifying this shouldn't be a problem as it should just detect which options we're passing.