### PR TITLE
Add pre-export validation warning for Link component

### DIFF
--- a/addons/io_hubs_addon/components/definitions/link.py
+++ b/addons/io_hubs_addon/components/definitions/link.py
@@ -29,6 +29,14 @@ class Link(HubsComponent):
 
         return migration_occurred
 
+    def pre_export(self, export_settings, host, ob=None):
+        warnings = []
+
+        if hasattr(self, "url") and not self.url:
+            warnings.append(f"{host.name}: Link component missing URL")
+
+        return warnings
+
     @classmethod
     def update_gizmo(cls, ob, bone, target, gizmo):
         if bone:


### PR DESCRIPTION
## What?
Adds a pre-export validation warning to the Link component.

If the Link component is missing its required URL/source field, it now returns a warning from `pre_export()`.

## Why?
This adds a small, component-specific validation example using the existing `HubsComponent.pre_export()` hook.

It improves export-time feedback while keeping the validation logic in the component class itself instead of the abstract base class.

## Examples
Example warning:

`Cube: Link component missing URL`

## How to test

1. Open Blender with the Hubs Blender add-on enabled
2. Add an object to the scene
3. Add the Link component to the object
4. Leave the link URL/source field empty
5. Trigger export or the relevant pre-export path
6. Confirm the warning is returned from `pre_export()`

## Documentation of functionality
No documentation changes required. This is an internal validation improvement.

## Limitations
This PR only adds validation for the Link component.
Warnings are not yet aggregated into a dedicated UI/report panel.

## Alternative implementations considered
Adding validation in the base `HubsComponent` class was considered, but rejected because required-field validation belongs in the specific component implementation.

## Open questions
None

## Additional details or related context
This is intended as a small first step toward broader component-level pre-export validation in the Blender add-on.