### PR TITLE
Add pre-export validation warning for Image component

### DIFF
--- a/addons/io_hubs_addon/components/definitions/image.py
+++ b/addons/io_hubs_addon/components/definitions/image.py
@@ -62,6 +62,14 @@ class Image(HubsComponent):
 
         return migration_occurred
 
+    def pre_export(self, export_settings, host, ob=None):
+        warnings = []
+
+        if hasattr(self, "src") and not self.src:
+            warnings.append(f"{host.name}: Image component missing source")
+
+        return warnings
+
     @classmethod
     def update_gizmo(cls, ob, bone, target, gizmo):
         if bone:


### PR DESCRIPTION
## What?
Adds a pre-export validation warning to the Image component.

If the Image component is missing its required source/reference field (e.g. `src`), the component now returns a warning from `pre_export()` before export.

## Why?
Currently, component configurations are not validated prior to export, which can lead to:
- missing or broken media in Hubs scenes
- unclear debugging when assets do not appear correctly

This PR introduces a small, component-specific validation using the existing `HubsComponent.pre_export()` hook, improving feedback without changing existing workflows.

## Examples
Example warning:

`Cube: Image component missing source`

## How to test

1. Open Blender with the Hubs Blender add-on enabled
2. Add an object to the scene
3. Add the Image component to the object
4. Leave the image source/reference field empty
5. Trigger export (e.g., Update Room Scene or Publish Scene)
6. Check the console output for the warning message

## Documentation of functionality
No documentation changes required. This is an internal validation improvement using existing component hooks.

## Limitations
- Validation is limited to the Image component in this PR
- Warnings are currently only surfaced via console output (no dedicated UI yet)

## Alternative implementations considered
- Adding validation logic in the base `HubsComponent` class was considered, but rejected since required-field validation is component-specific
- A centralized validation system was considered, but deferred to keep this PR focused and incremental

## Open questions
None

## Additional details or related context
This PR builds on the pattern introduced in earlier validation work and is intended as a step toward broader component-level validation across the add-on.