### PR TITLE
Ensure video validation is on this branch

### DIFF
--- a/addons/io_hubs_addon/components/definitions/video.py
+++ b/addons/io_hubs_addon/components/definitions/video.py
@@ -19,6 +19,15 @@ class Video(HubsComponent):
         'version': (1, 0, 0)
     }
 
+    def pre_export(self, export_settings, host, ob=None):
+        warnings = []
+
+        # Validate that a video source is provided
+        if not self.src or self.src.strip() == "":
+            warnings.append(f"{host.name}: Video component missing source URL")
+
+        return warnings
+
     src: StringProperty(
         name="Video URL", description="The web address of the video", default='https://example.org/VideoFile.webm')
 


### PR DESCRIPTION
## What?
Adds a pre-export validation warning to the Video component.

If the Video component is missing its required source URL (`src`), it now returns a warning from `pre_export()`.

## Why?
Currently, component configurations are not validated prior to export, which can lead to missing or broken media in Hubs scenes.

This PR adds a small, component-specific validation using the existing `HubsComponent.pre_export()` hook.

## Examples
Example warning:

`Cube: Video component missing source URL`

## How to test

1. Open Blender with the Hubs Blender add-on enabled
2. Add an object to the scene
3. Add the Video component to the object
4. Clear the "Video URL" field
5. Trigger export (e.g., Update Room Scene or Publish Scene)
6. Check the console for the warning

## Documentation of functionality
No documentation changes required.

## Limitations
- Only Video component validation is included in this PR
- Warnings are currently only printed via console

## Alternative implementations considered
- Centralized validation was considered but deferred in favor of component-level validation

## Open questions
None

## Additional details or related context
Part of incremental work toward broader component-level validation.