### PR TITLE
Ensure video validation is on this branch

### DIFF
--- a/addons/io_hubs_addon/components/definitions/video.py
+++ b/addons/io_hubs_addon/components/definitions/video.py
@@ -19,6 +19,15 @@ class Video(HubsComponent):
         'version': (1, 0, 0)
     }
 
+    def pre_export(self, export_settings, host, ob=None):
+        warnings = []
+
+        # Validate that a video source is provided
+        if not self.src or self.src.strip() == "":
+            warnings.append(f"{host.name}: Video component missing source URL")
+
+        return warnings
+
     src: StringProperty(
         name="Video URL", description="The web address of the video", default='https://example.org/VideoFile.webm')
 


### PR DESCRIPTION
## What?
Adds a `pre_export` validation step to the `video` component in `video.py` so the exporter warns when a Video component is missing its source URL.

Specifically, this change checks whether `self.src` is empty or only whitespace before export and appends a warning message identifying the affected host object.

## Why?
The Video component depends on a valid source URL to function correctly in Hubs. Without validation, users can export scenes containing Video components that appear configured in Blender but silently fail or behave unexpectedly at runtime because no actual media source was provided.

This change improves export-time feedback and helps catch misconfigured Video components earlier in the workflow.

## Examples
### Before
A user could export an object with a Video component whose source URL was empty, with no clear warning during export.

### After
If the Video component has no source URL, export returns a warning like:

`MyVideoObject: Video component missing source URL`

## How to test
1. Open Blender with the Hubs Blender Exporter add-on enabled.
2. Open or create a scene with an object that has a **Video** component.
3. Leave the **Video URL** field empty (or set it to whitespace only).
4. Export the scene using the Hubs/glTF export flow.
5. Confirm that the export process reports a warning indicating that the Video component is missing a source URL.
6. Repeat the export with a valid URL in the **Video URL** field.
7. Confirm that the warning is no longer produced.

## Documentation of functionality
No additional documentation is required for this change because it does not alter user-facing workflow beyond improving export validation feedback.

## Limitations
This PR only validates that a source URL exists. It does **not** validate:
- whether the URL is reachable,
- whether the media format is supported,
- whether the URL uses an expected protocol.

## Alternative implementations considered
- **Validation during property editing in the Blender UI**: rejected for now because export-time validation is simpler, less intrusive, and consistent with other pre-export checks.
- **Hard export failure instead of warning**: rejected because missing video URLs are better treated as a recoverable configuration issue than a fatal export error.

## Open questions
None.

## Additional details or related context
This follows the existing component lifecycle pattern by using `pre_export(...)` for validation before export proceeds.