### PR TITLE
Feature/interaction metadata enums

### DIFF
--- a/addons/io_hubs_addon/components/definitions/interaction_metadata.py
+++ b/addons/io_hubs_addon/components/definitions/interaction_metadata.py
@@ -1,0 +1,47 @@
+from bpy.props import StringProperty
+from ..hubs_component import HubsComponent
+from ..types import Category, PanelType, NodeType
+
+
+class InteractionMetadata(HubsComponent):
+    _definition = {
+        'name': 'interaction-metadata',
+        'display_name': 'Interaction Metadata',
+        'category': Category.MISC,
+        'node_type': NodeType.NODE,
+        'panel_type': [PanelType.OBJECT, PanelType.BONE],
+        'icon': 'PROPERTIES',
+        'version': (1, 0, 0)
+    }
+
+    behavior_type: StringProperty(
+        name="Behavior Type",
+        description="High-level behavior classification for downstream systems",
+        default=""
+    )
+
+    interaction_profile: StringProperty(
+        name="Interaction Profile",
+        description="Interaction mode or profile name",
+        default=""
+    )
+
+    simulation_tag: StringProperty(
+        name="Simulation Tag",
+        description="Simulation or systems tag for exported content",
+        default=""
+    )
+
+    def gather(self, export_settings, object):
+        data = {}
+
+        if self.behavior_type.strip():
+            data["behaviorType"] = self.behavior_type.strip()
+
+        if self.interaction_profile.strip():
+            data["interactionProfile"] = self.interaction_profile.strip()
+
+        if self.simulation_tag.strip():
+            data["simulationTag"] = self.simulation_tag.strip()
+
+        return data

--- a/addons/io_hubs_addon/components/definitions/interaction_metadata.py
+++ b/addons/io_hubs_addon/components/definitions/interaction_metadata.py
@@ -1,6 +1,26 @@
-from bpy.props import StringProperty
+from bpy.props import EnumProperty, StringProperty
 from ..hubs_component import HubsComponent
 from ..types import Category, PanelType, NodeType
+
+
+BEHAVIOR_TYPE_ITEMS = [
+    ("", "None", "No behavior type"),
+    ("agent", "Agent", "Autonomous agent"),
+    ("swarm", "Swarm", "Swarm / multi-agent system"),
+    ("trigger", "Trigger", "Trigger-based interaction"),
+    ("sensor", "Sensor", "Sensor or detection entity"),
+    ("static", "Static", "Non-interactive object"),
+]
+
+
+INTERACTION_PROFILE_ITEMS = [
+    ("", "None", "No interaction profile"),
+    ("grabbable", "Grabbable", "User can grab"),
+    ("clickable", "Clickable", "User can click"),
+    ("hoverable", "Hoverable", "Responds to hover"),
+    ("physics", "Physics", "Physics-driven interaction"),
+    ("ui", "UI", "User interface element"),
+]
 
 
 class InteractionMetadata(HubsComponent):
@@ -11,35 +31,37 @@ class InteractionMetadata(HubsComponent):
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'PROPERTIES',
-        'version': (1, 0, 0)
+        'version': (1, 1, 0)  # bump version
     }
 
-    behavior_type: StringProperty(
+    behavior_type: EnumProperty(
         name="Behavior Type",
-        description="High-level behavior classification for downstream systems",
+        description="High-level behavior classification",
+        items=BEHAVIOR_TYPE_ITEMS,
         default=""
     )
 
-    interaction_profile: StringProperty(
+    interaction_profile: EnumProperty(
         name="Interaction Profile",
-        description="Interaction mode or profile name",
+        description="Interaction mode",
+        items=INTERACTION_PROFILE_ITEMS,
         default=""
     )
 
     simulation_tag: StringProperty(
         name="Simulation Tag",
-        description="Simulation or systems tag for exported content",
+        description="Custom simulation tag",
         default=""
     )
 
     def gather(self, export_settings, object):
         data = {}
 
-        if self.behavior_type.strip():
-            data["behaviorType"] = self.behavior_type.strip()
+        if self.behavior_type:
+            data["behaviorType"] = self.behavior_type
 
-        if self.interaction_profile.strip():
-            data["interactionProfile"] = self.interaction_profile.strip()
+        if self.interaction_profile:
+            data["interactionProfile"] = self.interaction_profile
 
         if self.simulation_tag.strip():
             data["simulationTag"] = self.simulation_tag.strip()

--- a/addons/io_hubs_addon/components/definitions/video.py
+++ b/addons/io_hubs_addon/components/definitions/video.py
@@ -19,6 +19,15 @@ class Video(HubsComponent):
         'version': (1, 0, 0)
     }
 
+    def pre_export(self, export_settings, host, ob=None):
+        warnings = []
+
+        # Validate that a video source is provided
+        if not self.src or self.src.strip() == "":
+            warnings.append(f"{host.name}: Video component missing source URL")
+
+        return warnings
+
     src: StringProperty(
         name="Video URL", description="The web address of the video", default='https://example.org/VideoFile.webm')
 


### PR DESCRIPTION
## What?
Adds `pre_export(...)` validation to the `video` component to warn when a Video component is exported without a configured `src` value.

## Why?
Video components without a source URL are invalid in practice, but previously this could slip through export unnoticed. This change surfaces the issue earlier and makes scene configuration errors easier to debug.

## Examples
N/A

## How to test
1. Add a **Video** component to an object.
2. Leave **Video URL** blank.
3. Export the scene.
4. Verify a warning is shown for the object missing a video source.
5. Add a valid URL.
6. Export again.
7. Verify the warning no longer appears.

## Documentation of functionality
No documentation changes needed. This is an export-validation improvement.

## Limitations
Only checks for missing or whitespace-only URLs.

## Alternative implementations considered
None.

## Open questions
None.

## Additional details or related context
Uses the component `pre_export(...)` hook already supported by the exporter architecture.