### PR TITLE
Fix exporting glTF Separate with images

### DIFF
--- a/addons/io_hubs_addon/io/utils.py
+++ b/addons/io_hubs_addon/io/utils.py
@@ -7,7 +7,20 @@ from io_scene_gltf2.io.com import gltf2_io
 from typing import Optional, Tuple, Union
 
 # Version-specific imports
-if bpy.app.version >= (4, 3, 0):
+if bpy.app.version >= (4, 5, 0):
+    from io_scene_gltf2.blender.com import extras as gltf2_blender_extras
+    from io_scene_gltf2.blender.exp import joints as gltf2_blender_gather_joints
+    from io_scene_gltf2.blender.exp import nodes as gltf2_blender_gather_nodes
+    from io_scene_gltf2.blender.exp.cache import cached
+    from io_scene_gltf2.blender.exp.material import encode_image as gltf2_blender_image
+    from io_scene_gltf2.blender.exp.material import materials as gltf2_blender_gather_materials
+    from io_scene_gltf2.blender.exp.material import search_node_tree as gltf2_blender_search_node_tree
+    from io_scene_gltf2.blender.exp.material import texture_info as gltf2_blender_gather_texture_info
+    from io_scene_gltf2.blender.exp.material.image import set_real_uri as gltf2_blender_set_real_uri
+    from io_scene_gltf2.blender.imp.image import BlenderImage
+    from io_scene_gltf2.io.exp import binary_data as gltf2_io_binary_data
+    from io_scene_gltf2.io.exp import image_data as gltf2_io_image_data
+elif bpy.app.version >= (4, 3, 0):
     from io_scene_gltf2.blender.com import extras as gltf2_blender_extras
     from io_scene_gltf2.blender.exp import joints as gltf2_blender_gather_joints
     from io_scene_gltf2.blender.exp import nodes as gltf2_blender_gather_nodes
@@ -142,8 +155,11 @@ def gather_image(blender_image, export_settings):
         data = data[0]
 
     if export_settings['gltf_format'] == 'GLTF_SEPARATE':
+        # io_scene_gltf2.blender.exp.material.texture.__gather_source can be used as a reference for what's needed here.
         uri = HubsImageData(data=data, mime_type=mime_type, name=name)
         buffer_view = None
+        if bpy.app.version >= (4, 5, 0):
+            gltf2_blender_set_real_uri(uri, export_settings)
     else:
         uri = None
         buffer_view = gltf2_io_binary_data.BinaryData(data=data)


### PR DESCRIPTION
## What?
<!-- REQUIRED — Explain what your pull request does -->
Adds a call to the glTF add-on's set_real_uri function when gathering images for export in the glTF Separate format and adds a comment for where to reference future changes that may be needed.

## Why?
<!-- REQUIRED — Explain why you're opening this pull request, what limitations does it address, etc..  If you're fixing a bug with an open bug report you can just link to the bug report -->
To fix the failing environment-settings, lightmap, and reflection-probe tests reported in https://github.com/Hubs-Foundation/hubs-blender-exporter/issues/331.

The comment was added so that next time this function needs updating we'll have a starting point for how to update it.

## Examples
<!-- OPTIONAL — If applicable, give examples of the changes the user will observe, e.g. screenshots, videos, diagrams, console output, etc., otherwise put "N/A" or remove the section.  Including examples of before the PR and after the PR is encouraged. -->
N/A

## How to test
<!-- REQUIRED — Give the steps required to test your pull request -->

1. Open https://github.com/Hubs-Foundation/hubs-blender-exporter/blob/master/tests/scenes/environment-settings.blend in Blender 4.5+ (or any other blend file that has a component that uses an HDR image)
2. Export a glTF using the glTF Separate format.
3. See that the export completes successfully and that the images have been exported.
4. Run the tests on Blender 4.5 and see that they all pass.

## Documentation of functionality
<!-- REQUIRED — Link to the accompanying documentation pull request or identify where the documentation is located in this pull request.  If no documentation is needed, please specify this here -->
No functionality has changed, so no documentation update is needed.


## Known omissions or limitations
<!-- OPTIONAL — If there is anything you decided not to do/support in this PR that might otherwise be expected, list them here along with the reason why you didn't do/support them, otherwise put "None" -->
The issue fixed here is only part of why the tests are failing in recent Blender versions, so this won't make all the tests pass in Blender 5.0+.  See https://github.com/Hubs-Foundation/hubs-blender-exporter/pull/330 for more details on the issues with the tests.

## Alternative implementations considered
<!-- OPTIONAL — If there are any alternative ways of implementing this change that you thought of, but decided against, list them here along with why they were discarded, otherwise put "None" -->
None.

## Open questions
<!-- OPTIONAL — If you have any questions, put them here, otherwise put "None" -->
None.

## Additional details or related context
<!-- OPTIONAL — If there are any other details that you think the reviewers should be aware of that you didn't put elsewhere, e.g. links to related issues, pull requests, references you used, notes on weird things, attribution, etc., put them here, otherwise put "None" -->
The set_real_uri function, and it's use when exporting images in glTF Separate, was introduced in https://github.com/KhronosGroup/glTF-Blender-IO/pull/2515

Related to: https://github.com/Hubs-Foundation/hubs-blender-exporter/pull/345