### PR TITLE
Fix Loop Animation component export and tests in recent Blender versions

### DIFF
--- a/addons/io_hubs_addon/components/definitions/loop_animation.py
+++ b/addons/io_hubs_addon/components/definitions/loop_animation.py
@@ -398,12 +398,16 @@ def is_valid_shape_key_track(ob, track):
     return False
 
 
-def get_animation_name(ob, track):
+def get_animation_name(ob, track, export_settings):
     if is_valid_regular_action(ob, track) or is_valid_shape_key_action(ob, track):
         return track.name
     elif is_valid_regular_nla_track(ob, track) or is_valid_shape_key_nla_track(ob, track):
-        return track.track_name if not is_default_name(
-            track.track_name) else track.action_name
+        if bpy.app.version >= (4, 4, 0) and export_settings['gltf_animation_mode'] == 'ACTIONS':
+            nla_track = ob.animation_data.nla_tracks.get(track.track_name)
+            return nla_track.strips[0].action.name
+        else:
+            return track.track_name if not is_default_name(
+                track.track_name) else track.action_name
     else:
         return track.name
 
@@ -865,7 +869,7 @@ class LoopAnimation(HubsComponent):
     def gather(self, export_settings, object):
         final_track_names = []
         for track in object.hubs_component_loop_animation.tracks_list.values():
-            final_track_names.append(get_animation_name(object, track))
+            final_track_names.append(get_animation_name(object, track, export_settings))
 
         fps = bpy.context.scene.render.fps / bpy.context.scene.render.fps_base
 

--- a/addons/io_hubs_addon/components/definitions/loop_animation.py
+++ b/addons/io_hubs_addon/components/definitions/loop_animation.py
@@ -271,6 +271,25 @@ def is_useable_nla_track(animation_data, nla_track, track):
     action = nla_track.strips[0].action
     nla_track_fcurves = None
     if bpy.app.version >= (4, 4, 0):
+        if not action.slots:
+            Errors.log(track, 'NO_ACTION_SLOTS', "No slots are present in the action.")
+            return False
+
+        if not nla_track.strips[0].action_slot:
+            Errors.log(track, 'NO_ACTION_SLOT_IN_STRIP', "No action slot has been selected for the NLA track strip.")
+            return False
+
+        if not action.layers:
+            # Action layers aren't exposed in anything but the Python API as of Blender 5.0
+            Errors.log(track, 'NO_ACTION_LAYERS',
+                       "The action doesn't have any layers.\nDid you forget to add any keyframes to the action?")
+            return False
+
+        if not action.layers[0].strips:
+            # Action strips aren't exposed in anything but the Python API as of Blender 5.0
+            Errors.log(track, 'NO_ACTION_STRIPS', "No strips are present in the action layer.")
+            return False
+
         channelbag = action.layers[0].strips[0].channelbag(nla_track.strips[0].action_slot)
         nla_track_fcurves = channelbag.fcurves
     else:
@@ -291,8 +310,9 @@ def is_useable_nla_track(animation_data, nla_track, track):
     return True
 
 
-def is_usable_action(track):
+def is_usable_action(ob, track):
     action_name = track.name
+    action = ob.animation_data.action
 
     if action_name == '':
         Errors.log(track, 'FORBIDDEN_NAME', "Action names can't be nothing.")
@@ -303,11 +323,27 @@ def is_usable_action(track):
         Errors.log(track, 'FORBIDDEN_NAME', "Custom action names can't contain commas or spaces.")
         return False
 
+    if bpy.app.version >= (4, 4, 0):
+        if not action.slots:
+            Errors.log(track, 'NO_ACTION_SLOTS', "No slots are present in the action.")
+            return False
+
+        if not action.layers:
+            # Action layers aren't exposed in anything but the Python API as of Blender 5.0
+            Errors.log(track, 'NO_ACTION_LAYERS',
+                       "The action doesn't have any layers.\nDid you forget to add any keyframes to the action?")
+            return False
+
+        if not action.layers[0].strips:
+            # Action strips aren't exposed in anything but the Python API as of Blender 5.0
+            Errors.log(track, 'NO_ACTION_STRIPS', "No strips are present in the action layer.")
+            return False
+
     return True
 
 
 def is_valid_regular_action(ob, track):
-    if ob.animation_data and ob.animation_data.action and is_usable_action(track):
+    if ob.animation_data and ob.animation_data.action and is_usable_action(ob, track):
         action = ob.animation_data.action
         return not action_has_nla_track(ob, action) and track.name == action.name
     return False

--- a/addons/io_hubs_addon/components/definitions/loop_animation.py
+++ b/addons/io_hubs_addon/components/definitions/loop_animation.py
@@ -268,7 +268,15 @@ def is_useable_nla_track(animation_data, nla_track, track):
                    "The strip/track doesn't have an action.")
         return False
 
-    if not nla_track.strips[0].action.fcurves:
+    action = nla_track.strips[0].action
+    nla_track_fcurves = None
+    if bpy.app.version >= (4, 4, 0):
+        channelbag = action.layers[0].strips[0].channelbag(nla_track.strips[0].action_slot)
+        nla_track_fcurves = channelbag.fcurves
+    else:
+        nla_track_fcurves = action.fcurves
+
+    if not nla_track_fcurves:
         Errors.log(track, 'NO_FCURVES',
                    "The strip/track's action doesn't have any animation and\nwon't be exported.")
         return False

--- a/addons/io_hubs_addon/components/definitions/loop_animation.py
+++ b/addons/io_hubs_addon/components/definitions/loop_animation.py
@@ -292,13 +292,19 @@ def is_useable_nla_track(animation_data, nla_track, track):
             return False
 
         channelbag = action.layers[0].strips[0].channelbag(nla_track.strips[0].action_slot)
-        nla_track_fcurves = channelbag.fcurves
+        if channelbag:
+            nla_track_fcurves = channelbag.fcurves
     else:
         nla_track_fcurves = action.fcurves
 
     if not nla_track_fcurves:
-        Errors.log(track, 'NO_FCURVES',
-                   "The NLA track strip's action doesn't have any animation and\nwon't be exported.")
+        if bpy.app.version >= (4, 4, 0):
+            Errors.log(
+                track, 'NO_FCURVES',
+                "The NLA track strip's action doesn't have any animation in\nthe active slot and won't be exported.")
+        else:
+            Errors.log(track, 'NO_FCURVES',
+                       "The NLA track strip's action doesn't have any animation and\nwon't be exported.")
         return False
 
     if not is_unique_action(animation_data, nla_track):
@@ -314,6 +320,7 @@ def is_useable_nla_track(animation_data, nla_track, track):
 def is_usable_action(ob, track):
     action_name = track.name
     action = ob.animation_data.action
+    action_fcurves = None
 
     if action_name == '':
         Errors.log(track, 'FORBIDDEN_NAME', "Action names can't be nothing.")
@@ -339,6 +346,26 @@ def is_usable_action(ob, track):
             # Action strips aren't exposed in anything but the Python API as of Blender 5.0
             Errors.log(track, 'NO_ACTION_STRIPS', "No strips are present in the action layer.")
             return False
+
+        try:
+            active_slot = [slot for slot in action.slots if ob in slot.users()][0]
+            channelbag = action.layers[0].strips[0].channelbag(active_slot)
+            if channelbag:
+                action_fcurves = channelbag.fcurves
+        except IndexError:
+            Errors.log(track, 'NO_ACTIVE_ACTION_SLOT', "No active slot is present in the action.")
+            return False
+    else:
+        action_fcurves = action.fcurves
+
+    if not action_fcurves:
+        if bpy.app.version >= (4, 4, 0):
+            Errors.log(track, 'NO_FCURVES',
+                       "The action doesn't have any animation in\nthe active slot and won't be exported.")
+        else:
+            Errors.log(track, 'NO_FCURVES',
+                       "The action doesn't have any animation and\nwon't be exported.")
+        return False
 
     return True
 

--- a/addons/io_hubs_addon/components/definitions/loop_animation.py
+++ b/addons/io_hubs_addon/components/definitions/loop_animation.py
@@ -229,6 +229,7 @@ def is_matching_track(nla_track_type, nla_track, track):
 
 
 def is_useable_nla_track(animation_data, nla_track, track):
+    # Error checking is handled from top level to bottom level, if something isn't present an error is logged and we return early.  This way we always know that the expected constructs are present, e.g. we verify X is valid, then all checks for properties of X are conducted afterwards and we know they won't crash.
     track_name = nla_track.name
     action_name = get_action_name(nla_track)
 
@@ -249,23 +250,23 @@ def is_useable_nla_track(animation_data, nla_track, track):
                        "Action names can't contain commas or spaces.")
             return False
 
-    if len(nla_track.strips) > 1:
-        Errors.log(track, 'MULTIPLE_STRIPS',
-                   "Only one strip is allowed in the track.")
+    if not nla_track.strips:
+        Errors.log(track, 'NO_NLA_TRACK_STRIPS', "No strips are present in the NLA track.")
         return False
 
-    if not nla_track.strips:
-        Errors.log(track, 'NO_STRIPS', "No strips are present in the track.")
+    if len(nla_track.strips) > 1:
+        Errors.log(track, 'MULTIPLE_NLA_TRACK_STRIPS',
+                   "Only one strip is allowed in the NLA track.")
         return False
 
     if nla_track.strips[0].mute:
-        Errors.log(track, 'MUTED_STRIP',
-                   "The strip is muted and won't export.")
+        Errors.log(track, 'MUTED_NLA_TRACK_STRIP',
+                   "The NLA track strip is muted and won't export.")
         return False
 
     if not action_name:
         Errors.log(track, 'NO_ACTION',
-                   "The strip/track doesn't have an action.")
+                   "The NLA track strip doesn't have an action.")
         return False
 
     action = nla_track.strips[0].action
@@ -297,13 +298,13 @@ def is_useable_nla_track(animation_data, nla_track, track):
 
     if not nla_track_fcurves:
         Errors.log(track, 'NO_FCURVES',
-                   "The strip/track's action doesn't have any animation and\nwon't be exported.")
+                   "The NLA track strip's action doesn't have any animation and\nwon't be exported.")
         return False
 
     if not is_unique_action(animation_data, nla_track):
         Errors.log(
             track, 'NON_UNIQUE_ACTION',
-            "This strip/track contains an action that is present in multiple\nstrips/tracks on this object and may not export correctly.",
+            "The NLA track strip contains an action that is present within\nmultiple NLA tracks on this object and may not export correctly.",
             severity="Warning")
         return False
 

--- a/tests/test/tests/loop-animation.js
+++ b/tests/test/tests/loop-animation.js
@@ -16,9 +16,18 @@ module.exports = {
         assert.strictEqual(utils.checkExtensionAdded(node, 'MOZ_hubs_components'), true);
 
         const ext = node.extensions['MOZ_hubs_components'];
+        const loopAnimation = ext['loop-animation'];
+
+        const clip_names = loopAnimation.clip.split(",").sort();
+        const animation_names = asset.animations.reduce((accumulator, animation) => {
+            accumulator.push(animation.name);
+            return accumulator;
+        }, []).sort();
+        assert.deepStrictEqual(clip_names, animation_names);
+
         assert.deepStrictEqual(ext, {
             "loop-animation": {
-                "clip": "sample_clip_track_name,sample_clip_action_push_down,sample_clip_action_stash",
+                "clip": loopAnimation.clip,
                 "startOffset": 0,
                 "timeScale": 1
             }


### PR DESCRIPTION
## What?
<!-- REQUIRED — Explain what your pull request does -->
* Fixes the Loop Animation component export with the new Actions API introduced in Blender 4.4 and the tests that are failing in Blender 5.0+.
* Adds new validation checks for the new Actions API and cleans the checks up a bit.
* Improves the tests to check the names exported to the component with the actual names of the animations that were exported and so better detect naming convention changes.  This is also required for the tests to pass in versions prior to Blender 4.4.

## Why?
<!-- REQUIRED — Explain why you're opening this pull request, what limitations does it address, etc..  If you're fixing a bug with an open bug report you can just link to the bug report -->
The tests for the Loop Animation were failing in Blender 5.0+ due to API removals in Blender 5.0 and the actual export isn't correct in some situations since Blender 4.4 (despite the tests passing - they only checked for whether the export matched what was expected, not whether it would actually work in Hubs).  Not everything was properly validated in the UI of the Loop Animation component for versions above Blender 4.4 either.

## Examples
<!-- OPTIONAL — If applicable, give examples of the changes the user will observe, e.g. screenshots, videos, diagrams, console output, etc., otherwise put "N/A" or remove the section.  Including examples of before the PR and after the PR is encouraged. -->
N/A

## How to test
<!-- REQUIRED — Give the steps required to test your pull request -->

1. Open https://github.com/Hubs-Foundation/hubs-blender-exporter/blob/master/tests/scenes/loop-animation.blend in Blender 4.2, 4.4, and 5.0 (and any others you want to test).
2. Export a glTF using the glTF Separate format for each Blender version.
3. Open the exported `.gltf` file for each Blender version in a text editor and see that the names in the clip property of the Loop Animation component match the names of the actual animations.
4. Run the tests on Blender 4.2, 4.4, and 5.0, and see that the Loop Animation component tests pass.
5. To check the new verification messages:
  - Add an action without a slot and select it in the Loop Animation component, then click on the track in the Loop Animation component to view the warning.  Repeat but push it down to an NLA track before selecting it in the loop animation component (you may have to remove the slot from the action again after pushing it down).
  - Push an action down to an NLA track, then unlink the action slot from the NLA track in the `Action Clip` subpanel in the N-Panel in the NLA track editor (you will need to select the strip for that track for it to show in the N-Panel), then select the NLA track in the Loop Animation component, then click on the track in the Loop Animation component to view the warning.
  - Add an action, and a slot but don't add any keyframes, and select it in the Loop Animation component, then click on the track in the Loop Animation component to view the warning for there being no layer in the action.  Repeat but push it down to an NLA track before selecting it in the loop animation component.
  - Add an action, and a slot, then add some keyframes and delete them, and select it in the Loop Animation component, then click on the track in the Loop Animation component to view the warning for there being no animation present in active slot for the action.  Repeat but push it down to an NLA track before selecting it in the loop animation component.
  - Add an action, and a slot, then add some keyframes, then unlink the slot and add a new slot, then select the action in the Loop Animation component, then click on the track in the Loop Animation component to view the warning for there being no animation present in the active slot for the action.  Repeat but push it down to an NLA track before selecting it in the loop animation component.
  - The warning about "No strips are present in the action layer" is to prepare for future versions of Blender and I don't think there's a way to trigger it currently.

## Documentation of functionality
<!-- REQUIRED — Link to the accompanying documentation pull request or identify where the documentation is located in this pull request.  If no documentation is needed, please specify this here -->
Mostly this just fixes bugs in recent Blender versions and doesn't change any functionality, so no documentation update is needed.  The changes to the validation include warnings to the user and so serve as its own documentation (these can be found in `addons/io_hubs_addon/components/definitions/loop_animation.py`).

## Known omissions or limitations
<!-- OPTIONAL — If there is anything you decided not to do/support in this PR that might otherwise be expected, list them here along with the reason why you didn't do/support them, otherwise put "None" -->
The issue fixed here is only part of why the tests are failing in recent Blender versions, so this won't make all the tests pass in Blender 5.0+.  See https://github.com/Hubs-Foundation/hubs-blender-exporter/pull/330 for more details on the issues with the tests.

## Alternative implementations considered
<!-- OPTIONAL — If there are any alternative ways of implementing this change that you thought of, but decided against, list them here along with why they were discarded, otherwise put "None" -->
None.

## Open questions
<!-- OPTIONAL — If you have any questions, put them here, otherwise put "None" -->
None.

## Additional details or related context
<!-- OPTIONAL — If there are any other details that you think the reviewers should be aware of that you didn't put elsewhere, e.g. links to related issues, pull requests, references you used, notes on weird things, attribution, etc., put them here, otherwise put "None" -->
Release notes for Blender 4.4 where the new Action API is introduced:
https://developer.blender.org/docs/release_notes/4.4/python_api/#slotted-actions

Release notes for Blender 5.0 where the legacy Action API is removed:
https://developer.blender.org/docs/release_notes/5.0/python_api/#animation-rigging

Related to: https://github.com/Hubs-Foundation/hubs-blender-exporter/pull/344