### PR TITLE
Test/configurable blender path

### DIFF
--- a/tests/test/test_export.js
+++ b/tests/test/test_export.js
@@ -9,16 +9,19 @@ const OUT_PREFIX = process.env.OUT_PREFIX || '../tests_out';
 process.env['BLENDER_USER_SCRIPTS'] = path.join(process.cwd(), '..');
 
 const blenderVersions = (() => {
-  if (process.platform == 'darwin') {
+  if (process.platform === 'darwin') {
     return [
-      "/Applications/Blender.app/Contents/MacOS/Blender"
+      process.env.BLENDER_PATH || "/Applications/Blender.app/Contents/MacOS/Blender"
+    ];
+  } else if (process.platform === 'linux') {
+    return [
+      process.env.BLENDER_PATH || "blender"
     ];
   }
-  else if (process.platform == 'linux') {
-    return [
-      "blender"
-    ];
-  }
+
+  return [
+    process.env.BLENDER_PATH || "blender"
+  ];
 })();
 
 const basePath = path.join(__dirname);


### PR DESCRIPTION
## What?
This PR allows the tests to use a custom Blender executable path via the `BLENDER_PATH` environment variable. 

## Why?
There were complaints raised that the test suite currently assumes Blender is installed at a fixed path on macOS:

`/Applications/Blender.app/Contents/MacOS/Blender`

That causes local test failures when Blender is installed elsewhere. The change in this PR preserves the current default while allowing developers to override the path in their environment.

## How to test
We can run the tests with a custom Blender path, for example:

`BLENDER_PATH="/path/to/Blender" yarn test-bail`

Confirm the test suite can run  successfully on your machine  without requiring Blender to be installed at the default macOS location.

## Documentation of functionality
No additional documentation required.

## Limitations
This change only makes the Blender executable path configurable. It does not change CI behavior or Blender version compatibility.

## Alternatives considered
Using a filesystem symlink to force Blender into the expected path, but an environment variable is more portable and less intrusive.

## Open questions
None.

## Additional details or related context
While debugging locally, tests initially failed because Blender was not installed at the hardcoded macOS path. After correcting the executable path, the full suite passed.