### PR TITLE
CI: Removes unneeded permissions & pins action versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Python Linter
-        uses: weibullguy/python-lint-plus@c1913ebcf442cb2901a919858b0146fef4f007fa
+        uses: weibullguy/python-lint-plus@c1913ebcf442cb2901a919858b0146fef4f007fa # v1.12.0
         with:
           python-root-list: "addons"
           use-black: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,9 +89,11 @@ jobs:
         if: ${{ !steps.blender_cache.outputs.cache-hit }}
         run: |
           mkdir /opt/blender
-          echo "Downloading: ${{ steps.blender_version.outputs.blender-url }}"
-          curl -SL "${{ steps.blender_version.outputs.blender-url }}" | \
+          echo "Downloading: ${STEPS_BLENDER_VERSION_OUTPUTS_BLENDER_URL}"
+          curl -SL "${STEPS_BLENDER_VERSION_OUTPUTS_BLENDER_URL}" | \
             tar -Jx -C /opt/blender --strip-components=1
+        env:
+          STEPS_BLENDER_VERSION_OUTPUTS_BLENDER_URL: ${{ steps.blender_version.outputs.blender-url }}
       - name: Set up workspace
         run: |
           sudo ln -s /opt/blender/blender /usr/local/bin/blender

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,17 +8,16 @@ on:
   pull_request:
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Python Linter
-        uses: weibullguy/python-lint-plus@v1.12.0
+        uses: weibullguy/python-lint-plus@c1913ebcf442cb2901a919858b0146fef4f007fa
         with:
           python-root-list: "addons"
           use-black: false
@@ -60,7 +59,7 @@ jobs:
         version: ["3.5.0", "3.4.0", "3.3.1", "2.93.9"]
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       # Finds latest Blender build, and outputs the hosted build's download URL.
       - name: Find latest Blender build
         id: blender_version
@@ -75,7 +74,7 @@ jobs:
       # Loads a cached build of Blender if available. If not available, this step
       # enqueues the /opt/blender directory to be cached after tests pass.
       - id: blender_cache
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         env:
           cache-name: cache-blender
         with:
@@ -106,7 +105,7 @@ jobs:
           cd tests
           OUT_PREFIX=$GITHUB_WORKSPACE/tests/out yarn test-bail --reporter-options reportDir=out/mochawesome
       - name: Upload test artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-output-${{ matrix.version }}
           path: tests/out/mochawesome
@@ -117,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Update build number
         run: |
           sed -i'' 's/"dev_build"/${{ github.run_number }}/g' $GITHUB_WORKSPACE/addons/io_hubs_addon/__init__.py
@@ -127,7 +126,7 @@ jobs:
           VERSION=$(grep '"version"' $GITHUB_WORKSPACE/addons/io_hubs_addon/__init__.py | sed -E 's/.*\(([0-9]+), ([0-9]+), ([0-9]+), ([0-9]+)\).*/\1.\2.\3.\4/')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
       - name: Upload addon artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: io_hubs_addon_${{ steps.get_version.outputs.version }}
           path: addons

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Python Linter
         uses: weibullguy/python-lint-plus@c1913ebcf442cb2901a919858b0146fef4f007fa
         with:
@@ -60,6 +62,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       # Finds latest Blender build, and outputs the hosted build's download URL.
       - name: Find latest Blender build
         id: blender_version
@@ -117,6 +121,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Update build number
         run: |
           sed -i'' 's/"dev_build"/${{ github.run_number }}/g' $GITHUB_WORKSPACE/addons/io_hubs_addon/__init__.py


### PR DESCRIPTION
## What?
1. CI: removes unneeded permissions
2. CI: pins actions versions
3. CI: sets persist-credentials false
4. changes workflow variable to shell variable


## Why?
to secure against supply chain attacks 

## Examples
n/a


## How to test
1. Merge these changes into the default branch of your personal repo
2. Push to GitHub
5. Check the Actions status; observe that all jobs still pass


## Documentation of functionality
no change to functionality


## Limitations
None


## Alternative implementations considered
None


## Open questions
None


## Additional details or related context
The latter actions are on the advice of zizmor, but they tally with what I read elsewhere.

